### PR TITLE
slight improvements to spacing rules (remove excess spacing)

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
@@ -34,7 +34,6 @@ class SolidityFormattingModelBuilder : FormattingModelBuilder {
 
   companion object {
     fun createSpacingBuilder(settings: CodeStyleSettings): SpacingBuilder {
-      val SOURCE_UNIT = TokenSet.create(CONTRACT_DEFINITION, IMPORT_DIRECTIVE, PRAGMA_DIRECTIVE)
       return SpacingBuilder(settings, SolidityLanguage)
         .after(TokenSet.create(LPAREN, LBRACE, LBRACKET)).none()
         // Some old versions do not support .before(TokenSet), so we use more verbose form
@@ -46,7 +45,8 @@ class SolidityFormattingModelBuilder : FormattingModelBuilder {
         .before(SEMICOLON).none()
         .around(BINARY_OPERATORS).spaces(1)
         .around(TokenSet.create(QUESTION, COLON, IS)).spaces(1)
-        .after(TokenSet.create(RETURNS, RETURN, IMPORT, MAPPING)).spaces(1)
+        .after(TokenSet.create(RETURNS, RETURN, IMPORT)).spaces(1)
+        .after(MAPPING).spaces(0)
         .afterInside(TokenSet.create(NOT, TILDE, INC, DEC, PLUS, MINUS), UNARY_EXPRESSION).none()
         .afterInside(DELETE, UNARY_EXPRESSION).spaces(1)
         .afterInside(SEMICOLON, FOR_STATEMENT).spaces(1)
@@ -74,10 +74,18 @@ class SolidityFormattingModelBuilder : FormattingModelBuilder {
         .afterInside(EXPRESSION, MEMBER_ACCESS_EXPRESSION).none()
         .beforeInside(IDENTIFIER, MEMBER_ACCESS_EXPRESSION).none()
         .between(IMPORT_DIRECTIVE, IMPORT_DIRECTIVE).blankLines(0)
-        .between(SOURCE_UNIT, SOURCE_UNIT).blankLines(2)
-        .between(SOURCE_UNIT, COMMENT).blankLines(2)
-        .between(TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION),
-          TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION)).blankLines(1)
+        // 1 line between pragma and import/contract definition
+        .between(PRAGMA_DIRECTIVE, TokenSet.create(IMPORT_DIRECTIVE, CONTRACT_DEFINITION)).blankLines(1)
+        // 1 line between pragma/import and contract definition
+        .between(TokenSet.create(PRAGMA_DIRECTIVE, IMPORT_DIRECTIVE), CONTRACT_DEFINITION).blankLines(1)
+        // 1 line between contracts
+        .between(CONTRACT_DEFINITION, CONTRACT_DEFINITION).blankLines(1)
+        // 0 lines between state variable declarations
+        .between(STATE_VARIABLE_DECLARATION, STATE_VARIABLE_DECLARATION).blankLines(0)
+        .between(
+          TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION),
+          TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION)
+        ).blankLines(1)
     }
   }
 }

--- a/src/test/resources/fixtures/formatter/blankLinesBetweenContracts-after.sol
+++ b/src/test/resources/fixtures/formatter/blankLinesBetweenContracts-after.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.4.0;
 
-
 contract test {}
-
 
 library test {}

--- a/src/test/resources/fixtures/formatter/lineComments-after.sol
+++ b/src/test/resources/fixtures/formatter/lineComments-after.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.0;
 
-
 // I'm a contract level line comment
 contract comments {
     // I'm a function level line comment

--- a/src/test/resources/fixtures/formatter/multisigWallet-after.sol
+++ b/src/test/resources/fixtures/formatter/multisigWallet-after.sol
@@ -1,10 +1,14 @@
 pragma solidity ^0.4.8;
 
+
 import "./ownership/Multisig.sol";
 import "./ownership/Shareable.sol";
 import "./DayLimit.sol";
 
+
 contract MultisigWallet is Multisig, Shareable, DayLimit {
+    address randomVariable1;
+    address randomVariable2;
 
     // comment1
     struct Transaction {

--- a/src/test/resources/fixtures/formatter/multisigWallet-after.sol
+++ b/src/test/resources/fixtures/formatter/multisigWallet-after.sol
@@ -1,10 +1,8 @@
 pragma solidity ^0.4.8;
 
-
 import "./ownership/Multisig.sol";
 import "./ownership/Shareable.sol";
 import "./DayLimit.sol";
-
 
 contract MultisigWallet is Multisig, Shareable, DayLimit {
 
@@ -73,5 +71,5 @@ contract MultisigWallet is Multisig, Shareable, DayLimit {
         super.clearPending();
     }
 
-    mapping (bytes32 => Transaction) txs;
+    mapping(bytes32 => Transaction) txs;
 }

--- a/src/test/resources/fixtures/formatter/multisigWallet.sol
+++ b/src/test/resources/fixtures/formatter/multisigWallet.sol
@@ -9,6 +9,8 @@ import  "./DayLimit.sol";
 
 
 contract  MultisigWallet  is  Multisig,  Shareable,  DayLimit  {
+address randomVariable1;
+    address randomVariable2;
 
     // comment1
     struct  Transaction  {


### PR DESCRIPTION
i tried to fix more of the problems people had with the rules but i'm not familiar enough with the interfaces. if you can guide me on the other problems that'd be great

also not sure why one test is failing when i used `./gradlew runIdea` to get the new -after files