### PR TITLE
The following wasn't documented as valid grammar.

### DIFF
--- a/src/main/grammars/grammar.txt
+++ b/src/main/grammars/grammar.txt
@@ -26,7 +26,7 @@ ModifierInvocation = Identifier ( '(' ExpressionList? ')' )?
 
 FunctionDefinition = 'function' Identifier? ParameterList
                      ( ModifierInvocation | StateMutability | 'external' | 'public' | 'internal' | 'private' )*
-                     ( 'returns' ParameterList )? ( ';' | Block )
+                     ( 'returns' ParameterList )? ( ';' | Block )
 EventDefinition = 'event' Identifier IndexedParameterList 'anonymous'? ';'
 
 EnumValue = Identifier
@@ -127,10 +127,10 @@ StringLiteral = '"' ([^"\r\n\\] | '\\' .)* '"'
 Identifier = [a-zA-Z_$] [a-zA-Z_$0-9]*
 
 HexNumber = '0x' [0-9a-fA-F]+
-DecimalNumber = [0-9]+
+DecimalNumber = [0-9]+ ( '.' [0-9]* )? ( [eE] [0-9]+ )?
 
-TupleExpression = '(' ( Expression ( ',' Expression )*  )? ')'
-                | '[' ( Expression ( ',' Expression )*  )? ']'
+TupleExpression = '(' ( Expression? ( ',' Expression? )*  )? ')'
+                | '[' ( Expression  ( ',' Expression  )*  )? ']'
 
 ElementaryTypeNameExpression = ElementaryTypeName
 
@@ -143,9 +143,9 @@ Uint = 'uint' | 'uint8' | 'uint16' | 'uint24' | 'uint32' | 'uint40' | 'uint48' |
 
 Byte = 'byte' | 'bytes' | 'bytes1' | 'bytes2' | 'bytes3' | 'bytes4' | 'bytes5' | 'bytes6' | 'bytes7' | 'bytes8' | 'bytes9' | 'bytes10' | 'bytes11' | 'bytes12' | 'bytes13' | 'bytes14' | 'bytes15' | 'bytes16' | 'bytes17' | 'bytes18' | 'bytes19' | 'bytes20' | 'bytes21' | 'bytes22' | 'bytes23' | 'bytes24' | 'bytes25' | 'bytes26' | 'bytes27' | 'bytes28' | 'bytes29' | 'bytes30' | 'bytes31' | 'bytes32'
 
-Fixed = 'fixed' | ( 'fixed' DecimalNumber 'x' DecimalNumber )
+Fixed = 'fixed' | ( 'fixed' [0-9]+ 'x' [0-9]+ )
 
-Uixed = 'ufixed' | ( 'ufixed' DecimalNumber 'x' DecimalNumber )
+Ufixed = 'ufixed' | ( 'ufixed' [0-9]+ 'x' [0-9]+ )
 
 InlineAssemblyBlock = '{' AssemblyItem* '}'
 


### PR DESCRIPTION
uint a;
(a,) = foo();

from https://github.com/ethereum/solidity/pull/3204