### PR TITLE
Function names completion

### DIFF
--- a/src/main/grammars/solidity.bnf
+++ b/src/main/grammars/solidity.bnf
@@ -371,12 +371,17 @@ FunctionCallExpression ::= (Identifier '(' FunctionCallArguments? ')') |
     implements = "me.serce.solidity.lang.psi.SolReferenceElement"
     mixin = "me.serce.solidity.lang.psi.impl.SolFunctionCallElement"
 }
+
 CallExpression ::= Expression ( ( '.' Identifier ) | ( '[' Expression ']' ) )* '(' FunctionCallArguments? ')' ('(' FunctionCallArguments? ')')*
 FunctionCallArguments ::= MapExpression | Expression? ( ',' Expression )*
 private MapExpressionClause ::= Identifier ':' Expression {pin=2}
 MapExpression ::= '{' MapExpressionClause (',' MapExpressionClause )* '}' {pin=1}
 
-NewExpression ::= new ( Identifier | PrimitiveLiteral )
+NewExpression ::= new ( Identifier | PrimitiveLiteral ) {
+    implements = "me.serce.solidity.lang.psi.SolReferenceElement"
+    mixin = "me.serce.solidity.lang.psi.impl.SolNewExpressionElement"
+}
+
 MemberAccessExpression ::= Expression '.' Identifier {
     pin = 2
     implements = "me.serce.solidity.lang.psi.SolReferenceElement"

--- a/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
@@ -22,60 +22,6 @@ import me.serce.solidity.lang.psi.SolStatement
  *
  * http://solidity.readthedocs.io/en/develop/units-and-global-variables.html#special-variables-and-functions
  */
-
-private val KEYWORD_PRIORITY = 10.0
-
-class SolKeywordCompletionProvider(private vararg val keywords: String) : CompletionProvider<CompletionParameters>() {
-  override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
-    keywords
-      .map { LookupElementBuilder.create(it) }
-      .forEach { result.addElement(it.keywordPrioritised()) }
-  }
-}
-
-class SolSimpleFunctionCompletionProvider(private vararg val functions: String) : CompletionProvider<CompletionParameters>() {
-  override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
-    functions
-      .map {
-        LookupElementBuilder.create(it).withTailText("()")
-          .withInsertHandler { context, _ ->
-            context.document.insertString(context.selectionEndOffset, "()")
-            EditorModificationUtil.moveCaretRelatively(context.editor, 1)
-          }
-      }
-      .forEach { result.addElement(it.keywordPrioritised()) }
-  }
-}
-
-class SolKeywordCompletionContributor : CompletionContributor(), DumbAware {
-  init {
-    extend(CompletionType.BASIC, rootDeclaration(),
-      SolKeywordCompletionProvider("pragma ", "import ", "contract ", "library "))
-    extend(CompletionType.BASIC, rootDeclaration(), object : CompletionProvider<CompletionParameters>() {
-      override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
-        val pragmaBuilder = LookupElementBuilder
-          .create("pragma solidity")
-          .bold()
-          .withTailText(" ^...")
-          .withInsertHandler { ctx, _ ->
-            ctx.document.insertString(ctx.selectionEndOffset, " ^0.4.4;")
-            EditorModificationUtil.moveCaretRelatively(ctx.editor, 9)
-          }
-        result.addElement(PrioritizedLookupElement.withPriority(pragmaBuilder, KEYWORD_PRIORITY - 5))
-      }
-    })
-
-    extend(CompletionType.BASIC, statement(),
-      SolSimpleFunctionCompletionProvider("assert", "addmod", "mulmod", "keccak256", "sha3", "sha256", "ripemd160",
-        "ecrecover", "revert"))
-
-    extend(CompletionType.BASIC, insideContract(),
-      SolKeywordCompletionProvider("this"))
-    extend(CompletionType.BASIC, insideContract(),
-      SolSimpleFunctionCompletionProvider("selfdestruct"))
-  }
-}
-
 class SolContextCompletionContributor : CompletionContributor(), DumbAware {
   init {
     // beginning of a statement inside a block
@@ -109,7 +55,7 @@ class SolContextCompletionContributor : CompletionContributor(), DumbAware {
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
           SolCompleter
             .completeEventName(parameters.position)
-            .map { insertParens(it, true) }
+            .map { insertParenthesis(it, true) }
             .forEach(result::addElement)
         }
       }
@@ -153,22 +99,19 @@ class SolBaseTypesCompletionContributor : CompletionContributor(), DumbAware {
 
 private fun <E> or(vararg patterns: ElementPattern<E>) = StandardPatterns.or(*patterns)
 
-private fun rootDeclaration() = psiElement<PsiElement>()
-  .withParents(SolPrimaryExpression::class.java, SolidityFile::class.java)
-
-private fun statement() = psiElement<PsiElement>()
+fun statement() = psiElement<PsiElement>()
   .inside(SolStatement::class.java)
 
-private fun insideContract() = psiElement<PsiElement>()
+fun insideContract() = psiElement<PsiElement>()
   .inside(SolContractDefinition::class.java)
 
 private inline fun <reified I : PsiElement> psiElement(): PsiElementPattern.Capture<I> {
   return psiElement(I::class.java)
 }
 
-private fun LookupElementBuilder.keywordPrioritised(): LookupElement = PrioritizedLookupElement.withPriority(this, KEYWORD_PRIORITY)
+fun LookupElementBuilder.keywordPrioritised(): LookupElement = PrioritizedLookupElement.withPriority(this, KEYWORD_PRIORITY)
 
-private fun insertParens(elem : LookupElementBuilder, finish : Boolean) =
+fun insertParenthesis(elem: LookupElementBuilder, finish: Boolean): LookupElementBuilder =
         elem.withInsertHandler { ctx, _ ->
             ctx.document.insertString(ctx.selectionEndOffset, if (finish) "();" else "()")
             EditorModificationUtil.moveCaretRelatively(ctx.editor, 1)

--- a/src/main/kotlin/me/serce/solidity/lang/completion/functions.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/functions.kt
@@ -1,0 +1,155 @@
+package me.serce.solidity.lang.completion
+
+import com.google.common.base.Joiner
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNamedElement
+import com.intellij.psi.TokenType
+import com.intellij.psi.util.PsiTreeUtil.findElementOfClassAtOffset
+import com.intellij.psi.util.PsiTreeUtil.getParentOfType
+import com.intellij.util.ProcessingContext
+import me.serce.solidity.ide.SolidityIcons
+import me.serce.solidity.lang.core.SolidityFile
+import me.serce.solidity.lang.core.SolidityTokenTypes
+import me.serce.solidity.lang.psi.*
+import me.serce.solidity.lang.resolve.SolResolver
+import me.serce.solidity.lang.types.SolInternalTypeFactory
+
+class SolFunctionCompletionContributor : CompletionContributor(), DumbAware {
+
+  init {
+    extend(CompletionType.BASIC, expression(), FunctionCompletionProvider)
+  }
+
+  override fun beforeCompletion(context: CompletionInitializationContext) {
+    val file = context.file
+    if (file is SolidityFile) {
+      if (context.completionType == CompletionType.BASIC) {
+        val dummySuffix = deduceSemicolonOrBracket(context.editor, file, context.startOffset)
+        context.dummyIdentifier = CompletionInitializationContext.DUMMY_IDENTIFIER_TRIMMED + dummySuffix
+      }
+    }
+  }
+}
+
+private fun deduceSemicolonOrBracket(editor: Editor, file: SolidityFile, startOffset: Int): String {
+  if (editor !is EditorEx) {
+    return ""
+  }
+
+  val element = file.findElementAt(startOffset)
+
+  val iterator = editor.highlighter.createIterator(startOffset)
+  if (iterator.atEnd()) {
+    return ""
+  }
+
+  if (iterator.tokenType === TokenType.WHITE_SPACE) {
+    iterator.advance()
+  }
+
+  if (!iterator.atEnd() && iterator.tokenType === SolidityTokenTypes.IDENTIFIER) {
+    iterator.advance()
+  }
+
+  if (!iterator.atEnd() && iterator.tokenType === SolidityTokenTypes.LPAREN
+    && getParentOfType(element, SolFunctionCallExpression::class.java) != null
+  ) {
+    return "" // function call
+  }
+
+  if (!iterator.atEnd() && iterator.tokenType === SolidityTokenTypes.RPAREN) {
+    iterator.advance()
+  }
+
+  if (!iterator.atEnd() && iterator.tokenType == SolidityTokenTypes.SEMICOLON) {
+    return ""
+  }
+
+  // lets check where we are in the source code
+  if (findElementOfClassAtOffset(file, startOffset, SolFunctionCallArguments::class.java, false) != null) {
+    return ""
+  }
+
+  // it may be array access
+  if (!iterator.atEnd() && iterator.tokenType === SolidityTokenTypes.RBRACKET) {
+    return "];"
+  }
+
+  return ");"
+}
+
+object FunctionCompletionProvider : CompletionProvider<CompletionParameters>() {
+  override fun addCompletions(
+    parameters: CompletionParameters,
+    context: ProcessingContext?,
+    result: CompletionResultSet
+  ) {
+    val position = parameters.originalPosition
+    val contract = getParentOfType(position, SolFunctionDefinition::class.java)?.contract ?: return
+    val globalRef = SolInternalTypeFactory.of(contract.project).globalType.ref
+    val availableRefs = contract.collectSupers.flatMap { SolResolver.resolveTypeName(it) } + globalRef + contract
+    availableRefs
+      .filterIsInstance<SolContractDefinition>()
+      .flatMap { it.functionDefinitionList + it.structDefinitionList }
+      .filterIsInstance<PsiNamedElement>()
+      .filterNot { it.name == null }
+      .map {
+        LookupElementBuilder
+          .create(it as PsiNamedElement)
+          .withBoldness(true)
+          .withIcon(SolidityIcons.FUNCTION)
+          .withTypeText(funcOutType(it))
+          .withTailText(funcInType(it))
+      }
+      .map { insertParenthesis(it, false) }
+      .forEach(result::addElement)
+  }
+
+}
+
+private fun funcOutType(elem: PsiElement) = when (elem) {
+  is SolFunctionDefinition -> {
+    val params = elem.parameterListList
+    when (params.size) {
+      2 -> {
+        val declaredOutTypes = params[1].parameterDefList.map { p -> p.typeName.text }
+        val joinedParams = Joiner.on(",").join(declaredOutTypes)
+        "($joinedParams)"
+      }
+      else -> ""
+    }
+  }
+  is SolStructDefinition -> {
+    val structName = elem.identifier?.text
+    "($structName)"
+  }
+  else -> ""
+}
+
+private fun funcInType(elem: PsiElement) = when (elem) {
+  is SolFunctionDefinition -> {
+    val declaredInTypes = elem.parameterListList[0].parameterDefList.map { formatParam(it) }
+    val joinedParams = Joiner.on(", ").join(declaredInTypes)
+    "($joinedParams)"
+  }
+  is SolStructDefinition -> {
+    val structFields = (elem.variableDeclarationList).map { v -> v.identifier?.text + ": " + v.typeName?.text }
+    val joinedParams = Joiner.on(", ").join(structFields)
+    "($joinedParams)"
+  }
+  else -> ""
+}
+
+private fun formatParam(param: SolParameterDef): String {
+  val id = param.identifier?.text
+  val type = param.typeName.text
+  return when (id) {
+    null -> type
+    else -> "$id: $type"
+  }
+}

--- a/src/main/kotlin/me/serce/solidity/lang/completion/keywords.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/keywords.kt
@@ -1,0 +1,44 @@
+package me.serce.solidity.lang.completion
+
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.editor.EditorModificationUtil
+import com.intellij.openapi.project.DumbAware
+import com.intellij.util.ProcessingContext
+
+const val KEYWORD_PRIORITY = 10.0
+
+class SolKeywordCompletionProvider(private vararg val keywords: String) : CompletionProvider<CompletionParameters>() {
+  override fun addCompletions(
+    parameters: CompletionParameters,
+    context: ProcessingContext?,
+    result: CompletionResultSet
+  ) {
+    keywords
+      .map { LookupElementBuilder.create(it) }
+      .forEach { result.addElement(it.keywordPrioritised()) }
+  }
+}
+
+class SolKeywordCompletionContributor : CompletionContributor(), DumbAware {
+  init {
+    extend(
+      CompletionType.BASIC, rootDeclaration(),
+      SolKeywordCompletionProvider("pragma ", "import ", "contract ", "library "))
+    extend(CompletionType.BASIC, rootDeclaration(), object : CompletionProvider<CompletionParameters>() {
+      override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext?, result: CompletionResultSet) {
+        val pragmaBuilder = LookupElementBuilder
+          .create("pragma solidity")
+          .bold()
+          .withTailText(" ^...")
+          .withInsertHandler { ctx, _ ->
+            ctx.document.insertString(ctx.selectionEndOffset, " ^0.4.4;")
+            EditorModificationUtil.moveCaretRelatively(ctx.editor, 9)
+          }
+        result.addElement(PrioritizedLookupElement.withPriority(pragmaBuilder, KEYWORD_PRIORITY - 5))
+      }
+    })
+
+    extend(CompletionType.BASIC, insideContract(), SolKeywordCompletionProvider("this"))
+  }
+}

--- a/src/main/kotlin/me/serce/solidity/lang/completion/locations.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/locations.kt
@@ -1,15 +1,40 @@
 package me.serce.solidity.lang.completion
 
-import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.patterns.StandardPatterns
+import com.intellij.psi.PsiElement
 import me.serce.solidity.lang.core.SolidityFile
 import me.serce.solidity.lang.core.SolidityTokenTypes
+import me.serce.solidity.lang.psi.SolFunctionCallArguments
+import me.serce.solidity.lang.psi.SolFunctionCallExpression
 import me.serce.solidity.lang.psi.SolPrimaryExpression
 
-fun emitStartStatement() = PlatformPatterns
-        .psiElement(SolidityTokenTypes.IDENTIFIER)
-        .afterLeaf(PlatformPatterns.psiElement(SolidityTokenTypes.EMIT))
 
-fun stateVarInsideContract() = PlatformPatterns
-  .psiElement(SolidityTokenTypes.IDENTIFIER)
-  .inside(PlatformPatterns.psiElement(SolPrimaryExpression::class.java))
-  .inside(SolidityFile::class.java)
+fun emitStartStatement() =
+  psiElement(SolidityTokenTypes.IDENTIFIER)
+    .afterLeaf(psiElement(SolidityTokenTypes.EMIT))
+
+fun stateVarInsideContract() =
+  psiElement(SolidityTokenTypes.IDENTIFIER)
+    .inside(psiElement(SolPrimaryExpression::class.java))
+    .inside(SolidityFile::class.java)
+
+fun rootDeclaration(): ElementPattern<PsiElement> = psiElement()
+  .withSuperParent(2, SolPrimaryExpression::class.java)
+  .withSuperParent(3, SolidityFile::class.java)
+
+fun expression(): ElementPattern<PsiElement> =
+  StandardPatterns.or(
+    functionCall(), primaryExpression(), functionCallArguments()
+  )
+
+fun functionCall(): ElementPattern<PsiElement> =
+  psiElement(SolidityTokenTypes.IDENTIFIER).inside(SolFunctionCallExpression::class.java)
+
+fun primaryExpression(): ElementPattern<PsiElement> =
+  psiElement(SolidityTokenTypes.IDENTIFIER).inside(SolPrimaryExpression::class.java)
+
+fun functionCallArguments(): ElementPattern<PsiElement> =
+  psiElement(SolidityTokenTypes.IDENTIFIER).inside(SolFunctionCallArguments::class.java);
+

--- a/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
@@ -180,6 +180,15 @@ abstract class SolFunctionCallElement(node: ASTNode) : SolNamedElementImpl(node)
   override fun getReference() = SolFunctionCallReference(this)
 }
 
+abstract class SolNewExpressionElement(node: ASTNode) : SolNamedElementImpl(node), SolNewExpression {
+  override val referenceNameElement: PsiElement
+    get() = findChildByType(IDENTIFIER) ?: firstChild
+  override val referenceName: String
+    get() = referenceNameElement.text
+
+  override fun getReference() = SolNewExpressionReference(this)
+}
+
 abstract class SolEventDefMixin : SolStubbedNamedElementImpl<SolEventDefStub>, SolEventDefinition {
   constructor(node: ASTNode) : super(node)
   constructor(stub: SolEventDefStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -165,9 +165,14 @@ object SolResolver {
         it.name == element.referenceName &&
           it.indexedParameterList?.typeNameList?.size ?: 0 == element.argumentsNumber()
       }
+    val structDefinitions = contract.structDefinitionList
+      .filter {
+        it.name == element.referenceName
+      }
     return when {
       currentContractFunctions.isNotEmpty() -> currentContractFunctions
       eventDefinitions.isNotEmpty() -> eventDefinitions
+      structDefinitions.isNotEmpty() -> structDefinitions
       else -> contract.supers.asSequence()
         .flatMap { resolveTypeName(it).asSequence() }
         .filterIsInstance<SolContractDefinition>()

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolUserDefinedTypeNameReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolUserDefinedTypeNameReference.kt
@@ -46,6 +46,19 @@ class SolMemberAccessReference(element: SolMemberAccessExpression) : SolReferenc
   override fun getVariants() = SolCompleter.completeMemberAccess(element)
 }
 
+class SolNewExpressionReference(element: SolNewExpression) : SolReferenceBase<SolNewExpression>(element), SolReference {
+
+  override fun calculateDefaultRangeInElement(): TextRange {
+    return element.referenceNameElement.parentRelativeRange
+  }
+
+  override fun multiResolve(): Collection<PsiElement> {
+    val types = SolResolver.resolveTypeName(element)
+    return types
+      .filterIsInstance(SolContractDefinition::class.java)
+  }
+}
+
 class SolFunctionCallReference(element: SolFunctionCallElement) : SolReferenceBase<SolFunctionCallElement>(element), SolReference {
   override fun calculateDefaultRangeInElement(): TextRange {
     return element.referenceNameElement.parentRelativeRange

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,11 +74,13 @@
                                    implementationClass="me.serce.solidity.ide.hints.SolParameterInfoHandler"/>
 
         <completion.contributor language="Solidity"
+                                implementationClass="me.serce.solidity.lang.completion.SolBaseTypesCompletionContributor"/>
+        <completion.contributor language="Solidity"
                                 implementationClass="me.serce.solidity.lang.completion.SolKeywordCompletionContributor"/>
         <completion.contributor language="Solidity"
-                                implementationClass="me.serce.solidity.lang.completion.SolContextCompletionContributor"/>
+                                implementationClass="me.serce.solidity.lang.completion.SolFunctionCompletionContributor"/>
         <completion.contributor language="Solidity"
-                                implementationClass="me.serce.solidity.lang.completion.SolBaseTypesCompletionContributor"/>
+                                implementationClass="me.serce.solidity.lang.completion.SolContextCompletionContributor"/>
 
         <lang.formatter language="Solidity"
                         implementationClass="me.serce.solidity.ide.formatting.SolidityFormattingModelBuilder"/>

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolCompletionTestBase.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolCompletionTestBase.kt
@@ -11,7 +11,7 @@ abstract class SolCompletionTestBase : SolTestBase() {
       "Expected completions that contain $required, but no completions found"
     }
     if (strict) {
-      assertEquals(variants.map { it.lookupString }.toHashSet(), required.toHashSet())
+      assertEquals(required.toHashSet(), variants.map { it.lookupString }.toHashSet())
     } else {
       assertTrue(variants.map { it.lookupString }.toHashSet().containsAll(required))
     }

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolFunctionNamesCompletionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolFunctionNamesCompletionTest.kt
@@ -1,0 +1,52 @@
+package me.serce.solidity.lang.completion
+
+class SolFunctionNamesCompletionTest : SolCompletionTestBase() {
+
+  fun testFuncNameInsideFunctionBlock() = checkCompletion(hashSetOf("f_1", "f_2"), """
+    contract A {
+      function f_1() {}
+      function f_2() {}
+
+      function example() {
+        f_/*caret*/
+      }
+    }
+  """, true)
+
+  fun testFuncNameInsideIf() = checkCompletion(hashSetOf("f_1", "f_2"), """
+    contract A {
+      function f_1() {}
+      function f_2() {}
+
+      function example() {
+        if(a > b) {
+          f_/*caret*/
+        }
+      }
+    }
+  """, true)
+
+  fun testFuncNameInsideAssignment() = checkCompletion(hashSetOf("f_1", "f_2"), """
+    contract A {
+      function f_1() {}
+      function f_2() {}
+
+      function example() {
+        address a_1 = f_/*caret*/
+      }
+    }
+  """, true)
+
+  fun testFuncNameWithInheritance() = checkCompletion(hashSetOf("f_1", "f_2"), """
+    contract FunctionHolder {
+      function f_1() {}
+      function f_2() {}
+    }
+
+    contract A is FunctionHolder {
+      function example() {
+        address a_1 = f_/*caret*/
+      }
+    }
+  """, true)
+}

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolFunctionsCompletionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolFunctionsCompletionTest.kt
@@ -1,0 +1,148 @@
+package me.serce.solidity.lang.completion
+
+class SolFunctionsCompletionTest : SolCompletionTestBase() {
+
+  fun testFuncNameIfConditionPrimExpression() = checkCompletion(
+    hashSetOf("f_1", "f_2"), """
+    contract FunctionHolder {
+      function f_1() {}
+      function f_2() {}
+    }
+
+    contract A is FunctionHolder {
+      function example() {
+        if(/*caret*/)
+      }
+    }
+  """
+  )
+
+  fun testFuncNameIfConditionFunctionCall() = checkCompletion(
+    hashSetOf("f_1", "f_2"), """
+    contract FunctionHolder {
+      function f_1() {}
+      function f_2() {}
+    }
+
+    contract A is FunctionHolder {
+      function example() {
+        if(f_/*caret*/())
+      }
+    }
+
+  """
+  )
+
+  fun testFuncNameWhileCond() = checkCompletion(
+    hashSetOf("f_1", "f_2"), """
+    contract FunctionHolder {
+      function f_1() {}
+      function f_2() {}
+    }
+
+    contract A is FunctionHolder {
+      function example() {
+        while(f_/*caret*/)
+      }
+    }
+  """
+  )
+
+  fun testFuncNameReturn() = checkCompletion(
+    hashSetOf("f_1", "f_2"), """
+    contract FunctionHolder {
+      function f_1() {}
+      function f_2() {}
+    }
+
+    contract A is FunctionHolder {
+      function example() {
+        return /*caret*/
+      }
+    }
+  """
+  )
+
+  fun testFuncArgumentsTest() {
+    checkCompletion(
+      hashSetOf("f_1", "f_2"), """
+            contract FunctionHolder {
+              function f_1() {}
+              function f_2() {}
+            }
+
+            contract A is FunctionHolder {
+              function example(uint amount, uint balance) {
+                f_1(/*caret*/);
+              }
+            }
+          """, strict = false
+    )
+    checkCompletion(
+      hashSetOf("f_1", "f_2"), """
+            contract FunctionHolder {
+              function f_1() {}
+              function f_2() {}
+            }
+
+            contract A is FunctionHolder {
+              function example(uint amount, uint balance) {
+                f_1(amount, /*caret*/);
+              }
+            }
+          """, strict = false
+    )
+    checkCompletion(
+      hashSetOf("f_1", "f_2"), """
+            contract FunctionHolder {
+              function f_1() {}
+              function f_2() {}
+            }
+
+            contract A is FunctionHolder {
+              function example(uint amount, uint balance) {
+                f_1(/*caret*/, amount);
+              }
+            }
+          """
+    )
+
+    checkCompletion(
+      hashSetOf("param1", "param2"), """
+            contract A {
+              function example(uint param1, uint param2) {
+                f_1(/*caret*/, amount);
+              }
+            }
+          """
+    )
+
+    checkCompletion(
+      hashSetOf("param1", "param2"), """
+            contract A {
+              function example(uint param1, uint param2) {
+                f_1(amount, /*caret*/);
+              }
+            }
+          """
+    )
+  }
+
+  fun testFuncArgumentsTestIncompleteStatement() = checkCompletion(
+    hashSetOf("param1", "param2"), """
+            contract A {
+              function example(uint param1, uint param2) {
+                f_1(/*caret*/)
+              }
+            }
+          """
+  )
+
+  fun testFunIncomplete() = checkCompletion(
+    hashSetOf(), """
+            contract B {
+                function/*caret*/{}
+            }
+          """, strict = true
+  )
+}

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolKeywordCompletion.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolKeywordCompletion.kt
@@ -1,0 +1,18 @@
+package me.serce.solidity.lang.completion
+
+class SolKeywordCompletion : SolCompletionTestBase() {
+
+  fun testRootCompletion() = checkCompletion(
+    hashSetOf("pragma solidity", "pragma ", "library ", "contract "), """
+      /*caret*/
+  """
+  )
+
+  fun testContractKeyword() = checkCompletion(
+    hashSetOf("contract ", "library "), """
+        contract A{}
+        /*caret*/
+  """
+  )
+
+}

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolVarCompletionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolVarCompletionTest.kt
@@ -51,4 +51,45 @@ class SolVarCompletionTest : SolCompletionTestBase() {
             }
         }
   """)
+
+  fun testArrayIndexCompletionTest1() = checkCompletion(
+    hashSetOf("userIndex"), """
+        contract B {
+            address[] users;
+
+            function doit() {
+                uint userIndex = 0;
+                users[/*caret*/];
+            }
+        }
+  """
+  )
+
+  fun testArrayIndexCompletionTest2() = checkCompletion(
+    hashSetOf("userIndex"), """
+        contract B {
+            address[] users;
+
+            function doit() {
+                uint userIndex = 0;
+                users[/*caret*/]
+            }
+        }
+  """
+  )
+
+  fun testArrayAssignment() = checkCompletion(
+    hashSetOf("A"), """
+        contract B {
+            address[] users;
+            struct A {
+                uint a1;
+            }
+
+            function doit() {
+                users[userIndex] = /*caret*/;
+            }
+        }
+  """
+  )
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolContractResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolContractResolveTest.kt
@@ -3,6 +3,32 @@ package me.serce.solidity.lang.core.resolve
 import me.serce.solidity.lang.psi.SolNamedElement
 
 class SolContractResolveTest : SolResolveTestBase() {
+
+  fun testNewContractResolveToContractDefSelf() = checkByCode(
+    """
+        contract A {
+               //x
+          function resolve() {
+            A a = new A();
+                    //^
+          }
+        }
+          """
+  )
+
+  fun testNewContractResolveToContractDefAnother() = checkByCode(
+    """
+        contract B {}
+               //x
+        contract A {
+          function resolve() {
+            B a = new B();
+                    //^
+          }
+        }
+          """
+  )
+
   fun testField() = checkByCode("""
         contract A {}
                //x

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolStructResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolStructResolveTest.kt
@@ -12,4 +12,43 @@ class SolStructResolveTest : SolResolveTestBase() {
           //^
       }
   """)
+
+  fun testStructResolveOneField() = checkByCode("""
+      contract B {
+          struct Prop {
+                //x
+              uint prop1;
+          }
+
+          Prop prop = Prop(0);
+                      //^
+      }
+  """)
+
+  fun testStructResolveTwoFields() = checkByCode("""
+      contract B {
+          struct Prop {
+                //x
+              uint prop1;
+              uint prop2;
+          }
+
+          Prop prop = Prop(0, 1);
+                      //^
+      }
+  """)
+
+  fun testStructResolveInherited() = checkByCode("""
+      contract A {
+          struct Prop {
+                //x
+              uint prop1;
+              uint prop2;
+          }
+      }
+      contract B is A {
+          Prop prop = Prop(0, 1);
+                      //^
+      }
+  """)
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/resolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/resolveTest.kt
@@ -17,7 +17,7 @@ abstract class SolResolveTestBase : SolTestBase() {
       return
     }
 
-    val references = refElement.references.map { it?.resolve() }.filterNotNull()
+    val references = refElement.references.mapNotNull { it?.resolve() }
     assertTrue("Failed to resolve ${refElement.text}", references.isNotEmpty())
     val target = findElementInEditor<SolNamedElement>("x")
 

--- a/src/test/kotlin/me/serce/solidity/lang/types/SolExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/types/SolExpressionTypeProviderTest.kt
@@ -50,7 +50,7 @@ class SolExpressionTypeProviderTest : SolTestBase() {
     """
   }
 
-  fun testFunctionParameter() = checkPrimitiveTypes { value, type ->
+  fun testFunctionParameter() = checkPrimitiveTypes { _, type ->
     """
         contract A {
             function f($type x) {
@@ -61,7 +61,7 @@ class SolExpressionTypeProviderTest : SolTestBase() {
     """
   }
 
-  fun testStateVar() = checkPrimitiveTypes { value, type ->
+  fun testStateVar() = checkPrimitiveTypes { _, type ->
     """
       contract A {
           $type x;
@@ -122,7 +122,7 @@ class SolExpressionTypeProviderTest : SolTestBase() {
     }
   }
 
-  fun testContractParameter() = testContractTypes { name, type ->
+  fun testContractParameter() = testContractTypes { _, type ->
     """
         contract B {}
         contract A {
@@ -134,7 +134,7 @@ class SolExpressionTypeProviderTest : SolTestBase() {
     """
   }
 
-  fun testContractStateVar() = testContractTypes { name, type ->
+  fun testContractStateVar() = testContractTypes { _, type ->
     """
         contract B {}
         contract A {


### PR DESCRIPTION

1.  Added resolution of references in `new Contract expression` to Contract definition.
_**Example**_
```javascript
contract A {
       //x
          function resolve() {
            A a = new A();
                    //^
          }
}
```
2. Moved function/keywords completion contributors into its own modules (_functions.kt, keywords.kt_ ). Going to improve keyword completion.
3. Fixed references from struct construction code to struct definition. Was not resolved properly for multi field structs
    **_Example_**
```javascript
contract A {
  struct Prop {
        //x
              uint prop1;
              uint prop2;
          }
  function structResolve() {
          Prop prop = Prop(0, 1);
                      //^
  }
}
```
4. Changed dummy identifier initialization for function completions.
    Affects references completion and makes it more context sensitive.


