### PR TITLE
NewExpression.reference resolves to constructor if present (or to Contract)

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolUserDefinedTypeNameReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolUserDefinedTypeNameReference.kt
@@ -53,9 +53,26 @@ class SolNewExpressionReference(element: SolNewExpression) : SolReferenceBase<So
   }
 
   override fun multiResolve(): Collection<PsiElement> {
-    val types = SolResolver.resolveTypeName(element)
+    val types = SolResolver.resolveTypeNameUsingImports(element)
     return types
       .filterIsInstance(SolContractDefinition::class.java)
+      .flatMap {
+        val constructors = it.findConstructors()
+        if (constructors.isEmpty()) {
+          listOf(it)
+        } else {
+          constructors
+        }
+      }
+  }
+}
+
+fun SolContractDefinition.findConstructors(): List<SolElement> {
+  return if (!this.constructorDefinitionList.isEmpty()) {
+    this.constructorDefinitionList
+  } else {
+    this.functionDefinitionList
+      .filter { it.name == this.name }
   }
 }
 

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolEventCompletionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolEventCompletionTest.kt
@@ -41,5 +41,5 @@ class SolEventCompletionTest : SolCompletionTestBase() {
                 emit C/*caret*/
             }
         }
-  """, strict = true)
+  """)
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolContractResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolContractResolveTest.kt
@@ -1,5 +1,6 @@
 package me.serce.solidity.lang.core.resolve
 
+import me.serce.solidity.lang.psi.SolElement
 import me.serce.solidity.lang.psi.SolNamedElement
 
 class SolContractResolveTest : SolResolveTestBase() {
@@ -20,6 +21,38 @@ class SolContractResolveTest : SolResolveTestBase() {
     """
         contract B {}
                //x
+        contract A {
+          function resolve() {
+            B a = new B();
+                    //^
+          }
+        }
+          """
+  )
+
+  fun testNewResolveToConstructor() = checkByCodeSearchType<SolElement>(
+    """
+        contract B {
+          constructor() {
+               //x
+          }
+        }
+        contract A {
+          function resolve() {
+            B a = new B();
+                    //^
+          }
+        }
+          """
+  )
+
+  fun testNewResolveToConstructorFunction() = checkByCodeSearchType<SolElement>(
+    """
+        contract B {
+          function B() {
+                 //x
+          }
+        }
         contract A {
           function resolve() {
             B a = new B();

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/resolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/resolveTest.kt
@@ -7,6 +7,10 @@ import org.intellij.lang.annotations.Language
 
 abstract class SolResolveTestBase : SolTestBase() {
   protected fun checkByCode(@Language("Solidity") code: String) {
+    checkByCodeSearchType<SolNamedElement>(code)
+  }
+
+  protected inline fun <reified T : PsiElement> checkByCodeSearchType(@Language("Solidity") code: String) {
     val (refElement, data) = resolveInCode<SolNamedElement>(code)
 
     if (data == "unresolved") {
@@ -19,7 +23,7 @@ abstract class SolResolveTestBase : SolTestBase() {
 
     val references = refElement.references.mapNotNull { it?.resolve() }
     assertTrue("Failed to resolve ${refElement.text}", references.isNotEmpty())
-    val target = findElementInEditor<SolNamedElement>("x")
+    val target = findElementInEditor<T>("x")
 
     if (references.size == 1) {
       assertEquals(target, references.first())


### PR DESCRIPTION
fix #116 