### PR TITLE
Switch to openjdk8 to fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # https://docs.travis-ci.com/user/languages/java/#Caching
 before_cache:


### PR DESCRIPTION
Recent builds [started failing](https://travis-ci.org/intellij-solidity/intellij-solidity/jobs/564280887#L166) with `Expected feature release number in range of 9 to 14, but got: 8`. This is due to https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/4. 

The solution is to switch to openjdk8 which to be fair, should've been there from the beginning. 

