### PR TITLE
fix SolParameterInfoHandler for idea 2020.x

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/hints/AbstractParameterInfoHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/hints/AbstractParameterInfoHandler.kt
@@ -1,0 +1,31 @@
+package me.serce.solidity.ide.hints
+
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+abstract class AbstractParameterInfoHandler<O : PsiElement, T : Any> : ParameterInfoHandler<O, T> {
+
+  abstract fun findTargetElement(file: PsiFile, offset: Int): O?
+
+  abstract fun calculateParameterInfo(element: O): Array<T>?
+
+  final override fun findElementForParameterInfo(context: CreateParameterInfoContext): O? {
+    val element = findTargetElement(context.file, context.offset) ?: return null
+    context.itemsToShow = calculateParameterInfo(element) ?: return null
+    return element
+  }
+
+  final override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): O? {
+    return findTargetElement(context.file, context.offset)
+  }
+
+  override fun showParameterInfo(element: O, context: CreateParameterInfoContext) {
+    context.showHint(element, element.startOffset, this)
+  }
+}
+
+val PsiElement.startOffset: Int
+  get() = textRange.startOffset

--- a/src/test/kotlin/me/serce/solidity/ide/hints/SolParameterInfoHandlerTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/hints/SolParameterInfoHandlerTest.kt
@@ -166,6 +166,7 @@ class SolParameterInfoHandlerTest : SolTestBase() {
 
     val updateContext = MockUpdateParameterInfoContext(myFixture.editor, myFixture.file)
     val element = handler.findElementForUpdatingParameterInfo(updateContext) ?: throw AssertionFailedError("Parameter not found")
+    updateContext.parameterOwner = element
     handler.updateParameterInfo(element, updateContext)
     TestCase.assertEquals(index, updateContext.currentParameter)
   }


### PR DESCRIPTION
Parameter info stopped working in 2020.x version. This PR fixes this
@SerCeMan Previously was commiting through 0v1se account :)