### PR TITLE
Add inspection descriptions

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/inspections/SelfdestructRenameInspection.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/inspections/SelfdestructRenameInspection.kt
@@ -20,7 +20,7 @@ class SelfdestructRenameInspection : LocalInspectionTool() {
   private fun inspectCall(expr: SolFunctionCallExpression, holder: ProblemsHolder) {
     val name = expr.referenceName
     if (name == "suicide") {
-      holder.registerProblem(expr, "suicide is deprecated. rename to selfdestruct. EIP 6",
+      holder.registerProblem(expr, "Suicide is deprecated. rename to selfdestruct. EIP 6",
         RenameFix(expr, "selfdestruct"))
     }
   }

--- a/src/main/resources/inspectionDescriptions/LinearizationImpossible.html
+++ b/src/main/resources/inspectionDescriptions/LinearizationImpossible.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports when linearization of an inheritance graph is impossible.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/NoReturn.html
+++ b/src/main/resources/inspectionDescriptions/NoReturn.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports the function where the plugin detected a return variable is not assigned or the return statement is missing.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/ResolveName.html
+++ b/src/main/resources/inspectionDescriptions/ResolveName.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports the identifiers that can't be resolved.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/SelfdestructRename.html
+++ b/src/main/resources/inspectionDescriptions/SelfdestructRename.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+Reports the usages of deprecated suicide function.
+
+See https://eips.ethereum.org/EIPS/eip-6 for more information.
+
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/UnprotectedFunction.html
+++ b/src/main/resources/inspectionDescriptions/UnprotectedFunction.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+Reports function that might modify owners of the contract, but have no modifiers.
+
+See https://twitter.com/flyosity/status/887866459896123392 for more information.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/test/kotlin/me/serce/solidity/ide/inspections/SelfdestructInspectionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/inspections/SelfdestructInspectionTest.kt
@@ -4,7 +4,7 @@ class SelfdestructInspectionTest : SolInspectionsTestBase(SelfdestructRenameInsp
   fun test() = checkByText("""
         contract a {
             function a() {
-                /*@warning descr="suicide is deprecated. rename to selfdestruct. EIP 6"@*/suicide(owner)/*@/warning@*/;
+                /*@warning descr="Suicide is deprecated. rename to selfdestruct. EIP 6"@*/suicide(owner)/*@/warning@*/;
             }
         }
     """)


### PR DESCRIPTION
The change helps to avoids plenty of errors like below in the logs. 

```
2021-09-18 23:33:44,929 [1296676]  ERROR - spection.ui.InspectionNodeInfo - Last Action: InspectCode 
2021-09-18 23:42:41,450 [1833197]  ERROR - spection.ui.InspectionNodeInfo - Inspection #NoReturn has no description [Plugin: me.serce.solidity] 
com.intellij.diagnostic.PluginException: Inspection #NoReturn has no description [Plugin: me.serce.solidity]
	at com.intellij.codeInspection.ui.InspectionNodeInfo.<init>(InspectionNodeInfo.java:74)
	at com.intellij.codeInspection.ui.InspectionResultsView.createBaseRightComponentFor(InspectionResultsView.java:468)
	at com.intellij.codeInspection.ui.InspectionResultsView.showInRightPanel(InspectionResultsView.java:395)
	at com.intellij.codeInspection.ui.InspectionResultsView.syncRightPanel(InspectionResultsView.java:334)
	at com.intellij.codeInspection.ui.InspectionTree.lambda$new$0(InspectionTree.java:82)
	at java.desktop/javax.swing.tree.DefaultTreeSelectionModel.fireValueChanged(DefaultTreeSelectionModel.java:641)
	at com.intellij.ui.treeStructure.Tree$MySelectionModel.fireValueChanged(Tree.java:623)
```