### PR TITLE
Improve Syntax Highlighting

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -46,7 +46,7 @@ class SolidityAnnotator : Annotator {
       is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT_NAME)
       is SolStateVariableDeclaration -> {
         if (element.mutationModifier?.textMatches("constant") == true) {
-          applyColor(holder, element.identifier, SolColor.STATE_VARIABLE_NAME)
+          applyColor(holder, element.identifier, SolColor.CONSTANT_STATE_VARIABLE_NAME)
         } else {
           applyColor(holder, element.identifier, SolColor.STATE_VARIABLE_NAME)
         }

--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -23,11 +23,9 @@ class SolidityAnnotator : Annotator {
     when (element) {
       is SolNumberType -> applyColor(holder, element, SolColor.TYPE)
       is SolElementaryTypeName -> applyColor(holder, element, SolColor.TYPE)
-      is SolVarLiteral -> {
-        when(element.identifier.text) {
-          "super" -> applyColor(holder, element, SolColor.KEYWORD)
-          "msg", "block", "abi" -> applyColor(holder, element, SolColor.GLOBAL)
-        }
+      is SolMemberAccessExpression -> when(element.expression.firstChild.text) {
+        "super" -> applyColor(holder, element.expression.firstChild, SolColor.KEYWORD)
+        "msg", "block", "abi" -> applyColor(holder, element.expression.firstChild, SolColor.GLOBAL)
       }
       is SolErrorDefMixin -> {
         applyColor(holder, element.identifier, SolColor.KEYWORD)
@@ -70,10 +68,14 @@ class SolidityAnnotator : Annotator {
           is SolUserDefinedValueTypeDefinition -> applyColor(holder, element, SolColor.USER_DEFINED_VALUE_TYPE)
         }
       }
-      is SolFunctionCallElement -> when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {
-        is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
-        is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
-        else -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+      is SolFunctionCallElement -> when(element.firstChild.text) {
+        "keccak256" -> applyColor(holder, element.firstChild, SolColor.GLOBAL_FUNCTION_CALL)
+        "require" -> applyColor(holder, element.firstChild, SolColor.KEYWORD)
+        else -> when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {
+          is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
+          is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
+          else -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+        }
       }
     }
   }

--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -10,6 +10,7 @@ import me.serce.solidity.ide.colors.SolColor
 import me.serce.solidity.ide.hints.startOffset
 import me.serce.solidity.lang.psi.*
 import me.serce.solidity.lang.psi.impl.SolErrorDefMixin
+import me.serce.solidity.lang.resolve.SolResolver
 
 class SolidityAnnotator : Annotator {
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
@@ -22,6 +23,12 @@ class SolidityAnnotator : Annotator {
     when (element) {
       is SolNumberType -> applyColor(holder, element, SolColor.TYPE)
       is SolElementaryTypeName -> applyColor(holder, element, SolColor.TYPE)
+      is SolVarLiteral -> {
+        when(element.identifier.text) {
+          "super" -> applyColor(holder, element, SolColor.KEYWORD)
+          "msg", "block", "abi" -> applyColor(holder, element, SolColor.GLOBAL)
+        }
+      }
       is SolErrorDefMixin -> {
         applyColor(holder, element.identifier, SolColor.KEYWORD)
         element.nameIdentifier?.let { applyColor(holder, it, SolColor.ERROR_NAME) }
@@ -43,31 +50,32 @@ class SolidityAnnotator : Annotator {
       is SolContractDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.CONTRACT_NAME) }
       is SolStructDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.STRUCT_NAME) }
       is SolEventDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.EVENT_NAME) }
-      is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT_NAME)
+      is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT)
       is SolStateVariableDeclaration -> {
         if (element.mutationModifier?.textMatches("constant") == true) {
-          applyColor(holder, element.identifier, SolColor.CONSTANT_STATE_VARIABLE_NAME)
+          applyColor(holder, element.identifier, SolColor.CONSTANT)
         } else {
-          applyColor(holder, element.identifier, SolColor.STATE_VARIABLE_NAME)
+          applyColor(holder, element.identifier, SolColor.STATE_VARIABLE)
         }
       }
       is SolFunctionDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.FUNCTION_DECLARATION) }
       is SolModifierDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.FUNCTION_DECLARATION) }
       is SolModifierInvocation -> applyColor(holder, element.varLiteral.identifier, SolColor.FUNCTION_CALL)
-
-      // TODO: the following destroys IDE performance, but does provide correct contextual highlighting for
-      // TODO: types and function calls... probable smoking gun is `getReference()`?
-      // TODO: Default to previous behavior until performance issue is fixed
-      is SolUserDefinedTypeName -> applyColor(holder, element, SolColor.CONTRACT_REFERENCE)
-//      is SolUserDefinedTypeName -> when(element.reference?.resolve()) {
-//        is SolContractDefinition -> applyColor(holder, element, SolColor.CONTRACT_NAME)
-//        is SolStructDefinition -> applyColor(holder, element, SolColor.STRUCT_NAME)
-//      }
-//      is SolFunctionCallElement -> when(element.reference?.resolve()) {
-//        is SolFunctionDefinition -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
-//        is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
-//        is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
-//      }
+      is SolUserDefinedTypeName -> {
+        when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {
+          is SolContractDefinition -> applyColor(holder, element, SolColor.CONTRACT_NAME)
+          is SolStructDefinition -> applyColor(holder, element, SolColor.STRUCT_NAME)
+          is SolEnumDefinition -> applyColor(holder, element, SolColor.ENUM_NAME)
+          is SolUserDefinedValueTypeDefinition -> applyColor(holder, element, SolColor.USER_DEFINED_VALUE_TYPE)
+          is SolEventDefinition -> applyColor(holder, element, SolColor.EVENT_NAME)
+          is SolErrorDefinition -> applyColor(holder, element, SolColor.ERROR_NAME)
+        }
+      }
+      is SolFunctionCallElement -> when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {
+        is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
+        is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
+        else -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+      }
     }
   }
 

--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -49,6 +49,7 @@ class SolidityAnnotator : Annotator {
       }
       is SolContractDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.CONTRACT_NAME) }
       is SolStructDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.STRUCT_NAME) }
+      is SolEnumDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.ENUM_NAME) }
       is SolEventDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.EVENT_NAME) }
       is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT)
       is SolStateVariableDeclaration -> {
@@ -67,8 +68,6 @@ class SolidityAnnotator : Annotator {
           is SolStructDefinition -> applyColor(holder, element, SolColor.STRUCT_NAME)
           is SolEnumDefinition -> applyColor(holder, element, SolColor.ENUM_NAME)
           is SolUserDefinedValueTypeDefinition -> applyColor(holder, element, SolColor.USER_DEFINED_VALUE_TYPE)
-          is SolEventDefinition -> applyColor(holder, element, SolColor.EVENT_NAME)
-          is SolErrorDefinition -> applyColor(holder, element, SolColor.ERROR_NAME)
         }
       }
       is SolFunctionCallElement -> when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {

--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -3,33 +3,85 @@ package me.serce.solidity.ide.annotation
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.refactoring.suggested.endOffset
 import me.serce.solidity.ide.colors.SolColor
+import me.serce.solidity.ide.hints.startOffset
 import me.serce.solidity.lang.psi.*
 import me.serce.solidity.lang.psi.impl.SolErrorDefMixin
 
 class SolidityAnnotator : Annotator {
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
     if (element is SolElement) {
-      val highlight = highlight(element)
-      if (highlight != null) {
-        val (partToHighlight, color) = highlight
-        holder.newAnnotation(HighlightSeverity.INFORMATION, "")
-          .range(partToHighlight)
-          .textAttributes(color.textAttributesKey)
-          .create()
-      }
+      highlight(element, holder)
     }
   }
 
-  private fun highlight(element: SolElement): Pair<PsiElement, SolColor>? {
-    return when (element) {
-      is SolNumberType -> element to SolColor.KEYWORD
-      is SolElementaryTypeName -> element to SolColor.KEYWORD
-      is SolErrorDefMixin -> element.identifier to SolColor.KEYWORD
-      is SolRevertStatement -> element.firstChild to SolColor.KEYWORD
-      is SolUserDefinedTypeName -> element to SolColor.CONTRACT_REFERENCE
-      else -> null
+  private fun highlight(element: SolElement, holder: AnnotationHolder) {
+    when (element) {
+      is SolNumberType -> applyColor(holder, element, SolColor.TYPE)
+      is SolElementaryTypeName -> applyColor(holder, element, SolColor.TYPE)
+      is SolErrorDefMixin -> {
+        applyColor(holder, element.identifier, SolColor.KEYWORD)
+        element.nameIdentifier?.let { applyColor(holder, it, SolColor.ERROR_NAME) }
+      }
+      is SolHexLiteral -> {
+        if ((element.endOffset - element.startOffset) > 4) {
+          applyColor(holder, TextRange(element.startOffset, element.startOffset + 3), SolColor.KEYWORD)
+          applyColor(holder, TextRange(element.startOffset + 3, element.endOffset), SolColor.STRING)
+        } else {
+          applyColor(holder, element, SolColor.STRING)
+        }
+      }
+      is SolRevertStatement -> applyColor(holder, element.firstChild, SolColor.KEYWORD)
+      is SolOverrideSpecifier -> {
+        if ((element.endOffset - element.startOffset) > 8) {
+          applyColor(holder, TextRange(element.startOffset, element.startOffset + 8), SolColor.KEYWORD)
+        }
+      }
+      is SolContractDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.CONTRACT_NAME) }
+      is SolStructDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.STRUCT_NAME) }
+      is SolEventDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.EVENT_NAME) }
+      is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT_NAME)
+      is SolStateVariableDeclaration -> {
+        if (element.mutationModifier?.textMatches("constant") == true) {
+          applyColor(holder, element.identifier, SolColor.STATE_VARIABLE_NAME)
+        } else {
+          applyColor(holder, element.identifier, SolColor.STATE_VARIABLE_NAME)
+        }
+      }
+      is SolFunctionDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.FUNCTION_DECLARATION) }
+      is SolModifierDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.FUNCTION_DECLARATION) }
+      is SolModifierInvocation -> applyColor(holder, element.varLiteral.identifier, SolColor.FUNCTION_CALL)
+
+      // TODO: the following destroys IDE performance, but does provide correct contextual highlighting for
+      // TODO: types and function calls... probable smoking gun is `getReference()`?
+      // TODO: Default to previous behavior until performance issue is fixed
+      is SolUserDefinedTypeName -> applyColor(holder, element, SolColor.CONTRACT_REFERENCE)
+//      is SolUserDefinedTypeName -> when(element.reference?.resolve()) {
+//        is SolContractDefinition -> applyColor(holder, element, SolColor.CONTRACT_NAME)
+//        is SolStructDefinition -> applyColor(holder, element, SolColor.STRUCT_NAME)
+//      }
+//      is SolFunctionCallElement -> when(element.reference?.resolve()) {
+//        is SolFunctionDefinition -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+//        is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
+//        is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
+//      }
     }
+  }
+
+  private fun applyColor(holder: AnnotationHolder, element: PsiElement, color: SolColor) {
+    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+      .range(element)
+      .textAttributes(color.textAttributesKey)
+      .create()
+  }
+
+  private fun applyColor(holder: AnnotationHolder, range: TextRange, color: SolColor) {
+    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+      .range(range)
+      .textAttributes(color.textAttributesKey)
+      .create()
   }
 }

--- a/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
@@ -8,6 +8,18 @@ enum class SolColor(humanName: String, default: TextAttributesKey) {
   LINE_COMMENT("Comment", Defaults.LINE_COMMENT),
   NAT_SPEC_TAG("NatSpecTag", Defaults.DOC_COMMENT_TAG),
 
+  CONTRACT_NAME("Contract name", Defaults.CLASS_NAME),
+  STRUCT_NAME("Struct name", Defaults.CLASS_NAME),
+  ERROR_NAME("Error name", Defaults.CLASS_NAME),
+  EVENT_NAME("Event name", Defaults.CLASS_NAME),
+
+  CONSTANT_NAME("Constant name", Defaults.GLOBAL_VARIABLE),
+  CONSTANT_STATE_VARIABLE_NAME("Constant state variable name", Defaults.STATIC_FIELD),
+  STATE_VARIABLE_NAME("State variable name", Defaults.INSTANCE_FIELD),
+
+  FUNCTION_DECLARATION("Function declaration", Defaults.FUNCTION_DECLARATION),
+  FUNCTION_CALL("Function call", Defaults.FUNCTION_CALL),
+
   BRACES("Braces", Defaults.BRACES),
   BRACKETS("Brackets", Defaults.BRACKETS),
   PARENTHESES("Parentheses", Defaults.PARENTHESES),
@@ -16,6 +28,7 @@ enum class SolColor(humanName: String, default: TextAttributesKey) {
   NUMBER("Number", Defaults.NUMBER),
   STRING("String", Defaults.STRING),
   KEYWORD("Keyword", Defaults.KEYWORD),
+  TYPE("Type", Defaults.KEYWORD),
 
   OPERATION_SIGN("Operation signs", Defaults.OPERATION_SIGN),
   CONTRACT_REFERENCE("Contract reference", Defaults.CLASS_REFERENCE),

--- a/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
@@ -5,33 +5,32 @@ import com.intellij.openapi.options.colors.AttributesDescriptor
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Defaults
 
 enum class SolColor(humanName: String, default: TextAttributesKey) {
-  LINE_COMMENT("Comment", Defaults.LINE_COMMENT),
-  NAT_SPEC_TAG("NatSpecTag", Defaults.DOC_COMMENT_TAG),
+  LINE_COMMENT("Comments//Comment", Defaults.LINE_COMMENT),
+  NAT_SPEC_TAG("Comments//NatSpecTag", Defaults.DOC_COMMENT_TAG),
 
-  CONTRACT_NAME("Contract name", Defaults.CLASS_NAME),
-  STRUCT_NAME("Struct name", Defaults.CLASS_NAME),
-  ERROR_NAME("Error name", Defaults.CLASS_NAME),
-  EVENT_NAME("Event name", Defaults.CLASS_NAME),
+  CONTRACT_NAME("Types//Contract name", Defaults.CLASS_NAME),
+  STRUCT_NAME("Types//Struct name", Defaults.CLASS_NAME),
+  ERROR_NAME("Types//Error name", Defaults.CLASS_NAME),
+  EVENT_NAME("Types//Event name", Defaults.CLASS_NAME),
+  ENUM_NAME("Types//Enum name", Defaults.CLASS_NAME),
+  TYPE("Types//Value type", Defaults.KEYWORD),
+  USER_DEFINED_VALUE_TYPE("Types//User-defined value type", Defaults.CLASS_NAME),
 
-  CONSTANT_NAME("Constant name", Defaults.GLOBAL_VARIABLE),
-  CONSTANT_STATE_VARIABLE_NAME("Constant state variable name", Defaults.STATIC_FIELD),
-  STATE_VARIABLE_NAME("State variable name", Defaults.INSTANCE_FIELD),
+  GLOBAL("Identifiers//Global", Defaults.GLOBAL_VARIABLE),
+  CONSTANT("Identifiers//Constant", Defaults.STATIC_FIELD),
+  STATE_VARIABLE("Identifiers//State variable", Defaults.INSTANCE_FIELD),
 
-  FUNCTION_DECLARATION("Function declaration", Defaults.FUNCTION_DECLARATION),
-  FUNCTION_CALL("Function call", Defaults.FUNCTION_CALL),
+  FUNCTION_DECLARATION("Functions//Function declaration", Defaults.FUNCTION_DECLARATION),
+  FUNCTION_CALL("Functions//Function call", Defaults.FUNCTION_CALL),
 
-  BRACES("Braces", Defaults.BRACES),
-  BRACKETS("Brackets", Defaults.BRACKETS),
-  PARENTHESES("Parentheses", Defaults.PARENTHESES),
-  SEMICOLON("Semicolon", Defaults.SEMICOLON),
-
-  NUMBER("Number", Defaults.NUMBER),
-  STRING("String", Defaults.STRING),
-  KEYWORD("Keyword", Defaults.KEYWORD),
-  TYPE("Type", Defaults.KEYWORD),
-
-  OPERATION_SIGN("Operation signs", Defaults.OPERATION_SIGN),
-  CONTRACT_REFERENCE("Contract reference", Defaults.CLASS_REFERENCE),
+  BRACES("Other//Braces", Defaults.BRACES),
+  BRACKETS("Other//Brackets", Defaults.BRACKETS),
+  PARENTHESES("Other//Parentheses", Defaults.PARENTHESES),
+  SEMICOLON("Other//Semicolon", Defaults.SEMICOLON),
+  NUMBER("Other//Number", Defaults.NUMBER),
+  STRING("Other//String", Defaults.STRING),
+  KEYWORD("Other//Keyword", Defaults.KEYWORD),
+  OPERATION_SIGN("Other//Operation signs", Defaults.OPERATION_SIGN),
   ;
 
   val textAttributesKey = TextAttributesKey.createTextAttributesKey("me.serce.solidity.$name", default)

--- a/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/colors/SolColor.kt
@@ -22,6 +22,7 @@ enum class SolColor(humanName: String, default: TextAttributesKey) {
 
   FUNCTION_DECLARATION("Functions//Function declaration", Defaults.FUNCTION_DECLARATION),
   FUNCTION_CALL("Functions//Function call", Defaults.FUNCTION_CALL),
+  GLOBAL_FUNCTION_CALL("Functions//Global function call", Defaults.GLOBAL_VARIABLE),
 
   BRACES("Other//Braces", Defaults.BRACES),
   BRACKETS("Other//Brackets", Defaults.BRACKETS),

--- a/src/main/kotlin/me/serce/solidity/ide/highlighter.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/highlighter.kt
@@ -44,6 +44,8 @@ object SolHighlighter : SyntaxHighlighterBase() {
     literals().map { it to SolColor.KEYWORD }
   ).plus(
     operators().map { it to SolColor.OPERATION_SIGN }
+  ).plus(
+    types().map { it to SolColor.TYPE }
   ).mapValues { it.value.textAttributesKey }
 
   private fun keywords() = setOf<IElementType>(
@@ -52,10 +54,14 @@ object SolHighlighter : SyntaxHighlighterBase() {
     CONTRACT, LIBRARY, INTERFACE, IS, STRUCT, FUNCTION, ENUM,
     PUBLIC, PRIVATE, INTERNAL, EXTERNAL, CONSTANT, PURE, VIEW,
     IF, ELSE, FOR, WHILE, DO, BREAK, CONTINUE, THROW, USING, RETURN, RETURNS,
-    MAPPING, EVENT, /*ERROR,*/ ANONYMOUS, MODIFIER, ASSEMBLY, BYTENUMTYPE, BYTESNUMTYPE,
-    FIXEDNUMTYPE, INTNUMTYPE, UFIXEDNUMTYPE, UINTNUMTYPE, STRING, BOOL, ADDRESS,
+    MAPPING, EVENT, /*ERROR,*/ ANONYMOUS, MODIFIER, ASSEMBLY,
     VAR, STORAGE, MEMORY, WEI, ETHER, GWEI, SZABO, FINNEY, SECONDS, MINUTES, HOURS,
-    DAYS, WEEKS, YEARS, TYPE
+    DAYS, WEEKS, YEARS, TYPE, VIRTUAL, OVERRIDE
+  )
+
+  private fun types() = setOf<IElementType>(
+    BYTENUMTYPE, BYTESNUMTYPE, FIXEDNUMTYPE, INTNUMTYPE, UFIXEDNUMTYPE, UINTNUMTYPE,
+    STRING, BOOL, ADDRESS,
   )
 
   private fun literals() = setOf<IElementType>(BOOLEANLITERAL)

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -22,7 +22,11 @@ object SolResolver {
   fun resolveTypeNameUsingImports(element: PsiElement): Set<SolNamedElement> =
     CachedValuesManager.getCachedValue(element) {
       val result = if (element is SolFunctionCallElement) {
-        resolveEvent(element) + resolveError(element)
+        resolveError(element) +
+          resolveEvent(element) +
+          resolveContractUsingImports(element, element.containingFile, true) +
+          resolveEnum(element) +
+          resolveUserDefinedValueType(element)
       } else {
         resolveContractUsingImports(element, element.containingFile, true) +
           resolveEnum(element) +

--- a/src/main/resources/me/serce/solidity/ide/colors/highlighter_example.sol
+++ b/src/main/resources/me/serce/solidity/ide/colors/highlighter_example.sol
@@ -1,33 +1,44 @@
-pragma solidity ^0.4.11;
+<KEYWORD>pragma</KEYWORD> solidity ^0.4.11;
 
+<KEYWORD>import</KEYWORD> './Ownable.sol';
 
-import './Ownable.sol';
-
+<TYPE>uint8</TYPE> <KEYWORD>constant</KEYWORD> <CONSTANT_NAME>MASK</CONSTANT_NAME> = 0x01;
 
 /**
  * @title Claimable
  * @dev Extension for the Ownable contract, where the ownership needs to be claimed.
  * This allows the new owner to accept the transfer.
  */
-contract Claimable is <CONTRACT_REFERENCE>Ownable</CONTRACT_REFERENCE> {
-    <KEYWORD>address</KEYWORD> public pendingOwner;
+<KEYWORD>contract</KEYWORD> <CONTRACT_NAME>Claimable</CONTRACT_NAME> <KEYWORD>is</KEYWORD> <CONTRACT_REFERENCE>Ownable</CONTRACT_REFERENCE> {
 
-    modifier onlyPendingOwner() {
+    <KEYWORD>error</KEYWORD> <ERROR_NAME>InvalidAddress</ERROR_NAME>(<TYPE>address</TYPE> addr);
+
+    <KEYWORD>event</KEYWORD> <EVENT_NAME>TokenTransfer</EVENT_NAME>(<TYPE>uint256</TYPE> tokenId, <TYPE>address</TYPE> recipient);
+
+    <TYPE>bytes</TYPE> <KEYWORD>public</KEYWORD> <KEYWORD>constant</KEYWORD> <CONSTANT_STATE_VARIABLE_NAME>DATA</CONSTANT_STATE_VARIABLE_NAME> = <KEYWORD>hex</KEYWORD><STRING>"48656C6C6F2C20576F726C6421"</STRING>;
+    <TYPE>address</TYPE> <KEYWORD>public</KEYWORD> <STATE_VARIABLE_NAME>pendingOwner</STATE_VARIABLE_NAME>;
+
+    <KEYWORD>struct</KEYWORD> <STRUCT_NAME>Struct</STRUCT_NAME> {
+        <TYPE>bool</TYPE> flag;
+        <TYPE>uint</TYPE> count;
+    }
+
+    <KEYWORD>modifier</KEYWORD> <FUNCTION_DECLARATION>onlyPendingOwner</FUNCTION_DECLARATION>() {
         require(msg.sender == pendingOwner);
         _;
     }
 
-    function transferOwnership(<KEYWORD>address</KEYWORD> newOwner) onlyOwner {
+    <KEYWORD>function</KEYWORD> <FUNCTION_DECLARATION>transferOwnership</FUNCTION_DECLARATION>(<TYPE>address</TYPE> newOwner) <FUNCTION_CALL>onlyOwner</FUNCTION_CALL> {
         pendingOwner = newOwner;
     }
 
-    function claimOwnership() onlyPendingOwner {
+    <KEYWORD>function</KEYWORD> <FUNCTION_DECLARATION>claimOwnership</FUNCTION_DECLARATION>() <FUNCTION_CALL>onlyPendingOwner</FUNCTION_CALL> {
         owner = pendingOwner;
         pendingOwner = 0x0;
     }
 
-    function reclaimToken(<CONTRACT_REFERENCE>ERC20Basic</CONTRACT_REFERENCE> token) external onlyPendingOwner {
-        <KEYWORD>uint256</KEYWORD> balance = token.balanceOf(this);
+    <KEYWORD>function</KEYWORD> <FUNCTION_DECLARATION>reclaimToken</FUNCTION_DECLARATION>(<CONTRACT_REFERENCE>ERC20Basic</CONTRACT_REFERENCE> token) <KEYWORD>external</KEYWORD> <FUNCTION_CALL>onlyPendingOwner</FUNCTION_CALL> {
+        <TYPE>uint256</TYPE> balance = token.balanceOf(this);
         token.transfer(pendingOwner, balance);
     }
 }

--- a/src/main/resources/me/serce/solidity/ide/colors/highlighter_example.sol
+++ b/src/main/resources/me/serce/solidity/ide/colors/highlighter_example.sol
@@ -2,21 +2,21 @@
 
 <KEYWORD>import</KEYWORD> './Ownable.sol';
 
-<TYPE>uint8</TYPE> <KEYWORD>constant</KEYWORD> <CONSTANT_NAME>MASK</CONSTANT_NAME> = 0x01;
+<TYPE>uint8</TYPE> <KEYWORD>constant</KEYWORD> <CONSTANT>MASK</CONSTANT> = 0x01;
 
 /**
  * @title Claimable
  * @dev Extension for the Ownable contract, where the ownership needs to be claimed.
  * This allows the new owner to accept the transfer.
  */
-<KEYWORD>contract</KEYWORD> <CONTRACT_NAME>Claimable</CONTRACT_NAME> <KEYWORD>is</KEYWORD> <CONTRACT_REFERENCE>Ownable</CONTRACT_REFERENCE> {
+<KEYWORD>contract</KEYWORD> <CONTRACT_NAME>Claimable</CONTRACT_NAME> <KEYWORD>is</KEYWORD> <CONTRACT_NAME>Ownable</CONTRACT_NAME> {
 
     <KEYWORD>error</KEYWORD> <ERROR_NAME>InvalidAddress</ERROR_NAME>(<TYPE>address</TYPE> addr);
 
     <KEYWORD>event</KEYWORD> <EVENT_NAME>TokenTransfer</EVENT_NAME>(<TYPE>uint256</TYPE> tokenId, <TYPE>address</TYPE> recipient);
 
-    <TYPE>bytes</TYPE> <KEYWORD>public</KEYWORD> <KEYWORD>constant</KEYWORD> <CONSTANT_STATE_VARIABLE_NAME>DATA</CONSTANT_STATE_VARIABLE_NAME> = <KEYWORD>hex</KEYWORD><STRING>"48656C6C6F2C20576F726C6421"</STRING>;
-    <TYPE>address</TYPE> <KEYWORD>public</KEYWORD> <STATE_VARIABLE_NAME>pendingOwner</STATE_VARIABLE_NAME>;
+    <TYPE>bytes</TYPE> <KEYWORD>public</KEYWORD> <KEYWORD>constant</KEYWORD> <CONSTANT>DATA</CONSTANT> = <KEYWORD>hex</KEYWORD><STRING>"48656C6C6F2C20576F726C6421"</STRING>;
+    <TYPE>address</TYPE> <KEYWORD>public</KEYWORD> <STATE_VARIABLE>pendingOwner</STATE_VARIABLE>;
 
     <KEYWORD>struct</KEYWORD> <STRUCT_NAME>Struct</STRUCT_NAME> {
         <TYPE>bool</TYPE> flag;
@@ -24,7 +24,7 @@
     }
 
     <KEYWORD>modifier</KEYWORD> <FUNCTION_DECLARATION>onlyPendingOwner</FUNCTION_DECLARATION>() {
-        require(msg.sender == pendingOwner);
+        <KEYWORD>require</KEYWORD>(<GLOBAL>msg</GLOBAL>.sender == pendingOwner);
         _;
     }
 
@@ -37,8 +37,8 @@
         pendingOwner = 0x0;
     }
 
-    <KEYWORD>function</KEYWORD> <FUNCTION_DECLARATION>reclaimToken</FUNCTION_DECLARATION>(<CONTRACT_REFERENCE>ERC20Basic</CONTRACT_REFERENCE> token) <KEYWORD>external</KEYWORD> <FUNCTION_CALL>onlyPendingOwner</FUNCTION_CALL> {
-        <TYPE>uint256</TYPE> balance = token.balanceOf(this);
-        token.transfer(pendingOwner, balance);
+    <KEYWORD>function</KEYWORD> <FUNCTION_DECLARATION>reclaimToken</FUNCTION_DECLARATION>(<CONTRACT_NAME>ERC20Basic</CONTRACT_NAME> token) <KEYWORD>external</KEYWORD> <FUNCTION_CALL>onlyPendingOwner</FUNCTION_CALL> {
+        <TYPE>uint256</TYPE> balance = token.<FUNCTION_CALL>balanceOf</FUNCTION_CALL>(this);
+        token.<FUNCTION_CALL>transfer</FUNCTION_CALL>(pendingOwner, balance);
     }
 }


### PR DESCRIPTION
This PR includes the following changes to syntax highlighting:

* Add various missing keywords to keyword list
* Split types into their own color, which inherits from default keywords (`#1` from #21)
* Add highlighting for Contract, Struct, Error, and Event names in definitions (`#2` from #21)
* Add highlighting for hex literal strings
* Add highlighting for constant variables, constant state variables, and state variables
* Add highlighting for modifier definitions and invocations
* Add highlighting for function definitions (#185)

~Unfortunately, I ran into performance and memory leak issues while attempting to add contextual highlighting for contract, error, event, and function references.  I added a comment with the issue and code that should work if those issues are resolved.~

Edit: I discovered `SolResolver`, and made the following additional improvements:

* Added groups to color editor
* In `SolResolver.resolveTypeNameUsingImports`, if `element` is `SolFunctionCallElement`, resolve events and errors instead of normal resolution (contracts, enums, structs, and UDTs)
* If function call isn't an error or event, default to function call color (possibly fragile)
* Use keyword color for `super`
* Use global color for `msg`, `block`, and `abi` (I'm sure there's others I'm missing here)