### PR TITLE
fix #306: run function resolving with a write action priority

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/navigation/SolContractImplementationSearcher.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/navigation/SolContractImplementationSearcher.kt
@@ -3,6 +3,7 @@ package me.serce.solidity.ide.navigation
 import com.intellij.openapi.application.QueryExecutorBase
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.util.ProgressIndicatorUtils
 import com.intellij.openapi.util.Condition
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.DefinitionsScopedSearch.SearchParameters
@@ -34,7 +35,7 @@ fun SolContractDefinition.findAllImplementations(): HashSet<SolContractDefinitio
   // Run the implementation resolution under an empty progress to avoid the noisy
   // "Must be executed under progress indicator" error, see https://github.com/intellij-solidity/intellij-solidity/issues/295
   // TODO: would it be worth using a real progress here?   
-  ProgressManager.getInstance().runProcess({
+  ProgressIndicatorUtils.runInReadActionWithWriteActionPriority({
     while (implQueue.isNotEmpty() && implQueue.size < MAX_IMPLEMENTATIONS && implementations.size < MAX_IMPLEMENTATIONS) {
       val current = implQueue.poll()
       if (!implementations.add(current)) {


### PR DESCRIPTION
The change attempts to fix #306 by running resolving in a read action with a write action priority. 