### PR TITLE
fix #309: resolve the infinite recursion issue

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolReferenceBase.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolReferenceBase.kt
@@ -36,4 +36,13 @@ abstract class SolReferenceBase<T : SolReferenceElement>(element: T) : PsiPolyVa
     check(identifier.elementType == IDENTIFIER)
     identifier.replace(SolPsiFactory(identifier.project).createIdentifier(newName.replace(".sol", "")))
   }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+    other as SolReferenceBase<*>
+    return element == other.element
+  }
+
+  override fun hashCode() = element.hashCode()
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
@@ -1,10 +1,13 @@
 package me.serce.solidity.lang.core.resolve
 
+import com.intellij.openapi.util.RecursionManager
 import me.serce.solidity.lang.psi.SolFunctionCallExpression
 import me.serce.solidity.lang.psi.SolNamedElement
 
 class SolEventResolveTest : SolResolveTestBase() {
-  fun testEventWithNoArguments() = checkByCode("""
+
+  fun testEventWithNoArguments() = checkByCode(
+    """
         contract B {
             event Closed();
                     //x
@@ -13,9 +16,11 @@ class SolEventResolveTest : SolResolveTestBase() {
                 //^
             }
         }
-  """)
+  """
+  )
 
-  fun testEventParent() = checkByCode("""
+  fun testEventParent() = checkByCode(
+    """
         contract A {
             event Closed();
                     //x
@@ -27,9 +32,11 @@ class SolEventResolveTest : SolResolveTestBase() {
                 //^
             }
         }
-  """)
+  """
+  )
 
-  fun testEventWithParemeters() = checkByCode("""
+  fun testEventWithParemeters() = checkByCode(
+    """
         contract B {
             event Refunded(int a, uint256 b);
                     //x
@@ -39,7 +46,37 @@ class SolEventResolveTest : SolResolveTestBase() {
                 //^
             }
         }
-  """)
+  """
+  )
+
+  fun testContractTheSameNameAsEvent() {
+    // TODO: the test below fails on the latest Solidity compiler with
+    //    > SyntaxError: Functions are not allowed to have the same name as the contract.
+    //    > If you intend this to be a constructor, use "constructor(...) { ... }" to define it.
+    //    In this situation, resolve works incorrectly. However, what the test actually
+    //    verifies is that  a StackOverflowException isn't thrown,
+    //    see https://github.com/intellij-solidity/intellij-solidity/issues/309
+    // A recursion guard check is disabled to prevent c.i.o.u.RecursionManager.CachingPreventedException
+    // from being thrown. The case highlights another issue that's worth fixing.
+    RecursionManager.disableMissedCacheAssertions(testRootDisposable)
+    checkByCode(
+      """
+        contract B {
+            event B();
+                   
+            function close() public {
+                emit B();
+                   //^
+            }
+            
+            function B() {
+                   //x
+            }
+        }
+    """
+    )
+  }
+
 
   override fun checkByCode(code: String) {
     checkByCodeInternal<SolFunctionCallExpression, SolNamedElement>(code)


### PR DESCRIPTION
A missing equals/hashcode was preventing a recursion guard defined in resolving to work correctly with references. 