### PR TITLE
Resolve top-level Enums, Structs, Errors, and user-defined types from imports w/ various fixes

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -74,7 +74,13 @@ class SolidityAnnotator : Annotator {
         else -> when(SolResolver.resolveTypeNameUsingImports(element).firstOrNull()) {
           is SolErrorDefinition -> applyColor(holder, element.referenceNameElement, SolColor.ERROR_NAME)
           is SolEventDefinition -> applyColor(holder, element.referenceNameElement, SolColor.EVENT_NAME)
-          else -> applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+          else -> element.firstChild.let {
+            if (it is SolPrimaryExpression && SolResolver.resolveTypeNameUsingImports(element.firstChild).filterIsInstance<SolStructDefinition>().isNotEmpty()) {
+              applyColor(holder, element.referenceNameElement, SolColor.STRUCT_NAME)
+            } else {
+              applyColor(holder, element.referenceNameElement, SolColor.FUNCTION_CALL)
+            }
+          }
         }
       }
     }

--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -49,6 +49,7 @@ class SolidityAnnotator : Annotator {
       is SolStructDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.STRUCT_NAME) }
       is SolEnumDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.ENUM_NAME) }
       is SolEventDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.EVENT_NAME) }
+      is SolUserDefinedValueTypeDefinition -> element.identifier?.let { applyColor(holder, it, SolColor.USER_DEFINED_VALUE_TYPE) }
       is SolConstantVariableDeclaration -> applyColor(holder, element.identifier, SolColor.CONSTANT)
       is SolStateVariableDeclaration -> {
         if (element.mutationModifier?.textMatches("constant") == true) {

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -82,21 +82,21 @@ object SolResolver {
   private fun resolveContract(element: PsiElement): Set<SolContractDefinition> =
     resolveUsingImports(SolContractDefinition::class.java, element, element.containingFile, true)
   private fun resolveEnum(element: PsiElement): Set<SolNamedElement> =
-    resolveUsingImports(SolEnumDefinition::class.java, element, element.containingFile, true) + resolveInnerType<SolEnumDefinition>(element) { it.enumDefinitionList }
+    resolveInnerType<SolEnumDefinition>(element) { it.enumDefinitionList } + resolveUsingImports(SolEnumDefinition::class.java, element, element.containingFile, true)
 
   private fun resolveStruct(element: PsiElement): Set<SolNamedElement> =
-    resolveUsingImports(SolStructDefinition::class.java, element, element.containingFile, true) + resolveInnerType<SolStructDefinition>(element) { it.structDefinitionList }
+    resolveInnerType<SolStructDefinition>(element) { it.structDefinitionList } + resolveUsingImports(SolStructDefinition::class.java, element, element.containingFile, true)
 
   private fun resolveUserDefinedValueType(element: PsiElement): Set<SolNamedElement> =
-    resolveUsingImports(SolUserDefinedValueTypeDefinition::class.java, element, element.containingFile, true) + resolveInnerType<SolUserDefinedValueTypeDefinition>(
+    resolveInnerType<SolUserDefinedValueTypeDefinition>(
       element,
-      { it.userDefinedValueTypeDefinitionList })
+      { it.userDefinedValueTypeDefinitionList }) + resolveUsingImports(SolUserDefinedValueTypeDefinition::class.java, element, element.containingFile, true)
 
   private fun resolveEvent(element: PsiElement): Set<SolNamedElement> =
     resolveInnerType<SolEventDefinition>(element) { it.eventDefinitionList }
 
   private fun resolveError(element: PsiElement): Set<SolNamedElement> =
-    resolveInnerType<SolErrorDefinition>(element) { it.errorDefinitionList }
+    resolveInnerType<SolErrorDefinition>(element) { it.errorDefinitionList } + resolveUsingImports(SolErrorDefinition::class.java, element, element.containingFile, true)
 
   private inline fun <reified T : SolNamedElement> resolveInFile(element: PsiElement) : Set<T> {
     return element.parentOfType<SolidityFile>()

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
@@ -93,6 +93,15 @@ class SolFunctionCallReference(element: SolFunctionCallExpression) : SolReferenc
   }
 
   fun resolveFunctionCall(): Collection<SolCallable> {
+    if (element.parent is SolRevertStatement) {
+      return SolResolver.resolveTypeNameUsingImports(element).filterIsInstance<SolErrorDefinition>()
+    }
+    if (element.firstChild is SolPrimaryExpression) {
+      val structs = SolResolver.resolveTypeNameUsingImports(element.firstChild).filterIsInstance<SolStructDefinition>()
+      if (structs.isNotEmpty()) {
+        return structs
+      }
+    }
     val resolved: Collection<SolCallable> = when (val expr = element.expression) {
       is SolPrimaryExpression -> {
         val regular = expr.varLiteral?.let { SolResolver.resolveVarLiteral(it) }

--- a/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
@@ -73,6 +73,7 @@ private fun getSolTypeFromUserDefinedTypeName(type: SolUserDefinedTypeName): Sol
         is SolContractDefinition -> SolContract(it)
         is SolStructDefinition -> SolStruct(it)
         is SolEnumDefinition -> SolEnum(it)
+        is SolUserDefinedValueTypeDefinition -> getSolType(it.elementaryTypeName)
         else -> null
       }
     }


### PR DESCRIPTION
This PR generalizes the logic from `SolResolver.resolveContractUsingImports(...)` to extend it to more items that can be imported:
* `contract`, `interface`, `library` (All handled by grammar as "contract")
* `enum` (top-level)
* `struct` (top-level)
* `error` (top-level)
* User-defined types (top-level)

This allows types to be highlighted and jumped to correctly.

This PR also includes the following small fixes:
* User-defined type names are now highlighted in the type definition
* Struct initialization is now highlighted as a struct name instead of a function call
* "Jump to" in struct initialization now correctly finds struct definition
* "Jump to" in revert expression now correctly finds error definition