### PR TITLE
Replace internal types with bundled globals file

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/inspections/NoReturnInspection.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/inspections/NoReturnInspection.kt
@@ -4,8 +4,7 @@ import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElementVisitor
 import me.serce.solidity.lang.psi.*
-import me.serce.solidity.lang.types.SolInternalTypeFactory
-import me.serce.solidity.lang.types.findContract
+import me.serce.solidity.lang.types.isGlobal
 
 class NoReturnInspection : LocalInspectionTool() {
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
@@ -208,9 +207,4 @@ private fun SolDeclarationItem.hasAssignment(el: SolNamedElement): Boolean {
 
 private fun SolTypedDeclarationItem.hasAssignment(el: SolNamedElement): Boolean {
   return this.identifier?.text == el.name
-}
-
-private fun SolElement.isGlobal(): Boolean {
-  val contract = this.findContract()
-  return contract == SolInternalTypeFactory.of(this.project).globalType.ref
 }

--- a/src/main/kotlin/me/serce/solidity/lang/completion/functions.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/functions.kt
@@ -90,7 +90,7 @@ object FunctionCompletionProvider : CompletionProvider<CompletionParameters>() {
     val position = parameters.originalPosition
 
     val availableRefs = getParentOfType(position, SolFunctionDefinition::class.java)?.contract?.let { contract ->
-      val globalRef = SolInternalTypeFactory.of(contract.project).globalType.ref
+      val globalRef = SolInternalTypeFactory.of(contract.project).globals.scope.ref
       contract.collectSupers.flatMap { SolResolver.resolveTypeName(it) } + globalRef + contract
     }?.filterIsInstance<SolContractDefinition>() ?: emptyList()
 

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -242,7 +242,7 @@ object SolResolver {
   }
 
   fun lexicalDeclarations(place: PsiElement, stop: (PsiElement) -> Boolean = { false }): Sequence<SolNamedElement> {
-    val globalType = SolInternalTypeFactory.of(place.project).globalType
+    val globalType = SolInternalTypeFactory.of(place.project).globals.scope
     return lexicalDeclarations(globalType.ref, place) + lexicalDeclRec(place, stop).distinct()
   }
 

--- a/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
@@ -62,8 +62,8 @@ fun getSolType(type: SolTypeName?): SolType {
 
 private fun getSolTypeFromUserDefinedTypeName(type: SolUserDefinedTypeName): SolType {
   val name = type.name
-  if (name != null && isInternal(name)) {
-    val internalType = SolInternalTypeFactory.of(type.project).byName(name)
+  if (name != null && type.referenceNameElement.isGlobal()) {
+    val internalType = SolInternalTypeFactory.of(type.project).globals.types[name]
     return internalType ?: SolUnknown
   }
   val resolvedTypes = SolResolver.resolveTypeNameUsingImports(type)

--- a/src/main/kotlin/me/serce/solidity/lang/types/internal.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/internal.kt
@@ -2,11 +2,25 @@ package me.serce.solidity.lang.types
 
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
-import me.serce.solidity.lang.psi.SolPsiFactory
-import me.serce.solidity.lang.types.SolInteger.Companion.UINT_256
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.util.ResourceUtil
+import me.serce.solidity.lang.core.SolidityFile
+import me.serce.solidity.lang.psi.*
+
+class SolGlobals(
+  val file: PsiFile,
+  val scope: SolContract,
+  val addressScope: SolContract,
+  val arrayScope: SolContract,
+  val functions: List<SolFunctionDefinition>,
+  val members: List<SolStateVariableDeclaration>,
+  val types: Map<String, SolContract>
+)
 
 class SolInternalTypeFactory(project: Project) {
-  private val psiFactory: SolPsiFactory = SolPsiFactory(project)
 
   companion object {
     fun of(project: Project): SolInternalTypeFactory {
@@ -14,87 +28,27 @@ class SolInternalTypeFactory(project: Project) {
     }
   }
 
-  private val registry: Map<String, SolType> by lazy {
-    listOf(
-      msgType,
-      txType,
-      blockType
-    ).associateBy { it.toString() }
+  val globals by lazy {
+    val url = ResourceUtil.getResource(this.javaClass.classLoader, "builtins", "solidity-0.8.15.sol")
+    val vf = VfsUtil.findFileByURL(url) ?: error("Could not find builtins virtual file!")
+    val file = PsiManager.getInstance(project).findFile(vf) ?: error("Could not find builtins psi file!")
+    val solFile = SolidityFile(file.viewProvider)
+    val contracts = solFile.findChildrenByClass(SolContractDefinition::class.java)
+    val globalsContract = SolContract(contracts.find { it.identifier?.text == "Globals" } ?: error("Could not find Globals contract in builtins file!"))
+    val types = contracts.filterNot { it.identifier?.text == "Globals" }.associateBy { it.identifier?.text ?: "" }.mapValues { (_, contract) -> SolContract(contract) }
+
+    SolGlobals(
+      file,
+      globalsContract,
+      SolContract(contracts.find { it.name == "Address" } ?: error("Could not find Address contract in builtins file!")),
+      SolContract(contracts.find { it.name == "Array" } ?: error("Could not find Array contract in builtins file!")),
+      globalsContract.getMembers(project).filterIsInstance<SolFunctionDefinition>(),
+      globalsContract.getMembers(project).filterIsInstance<SolStateVariableDeclaration>(),
+      types,
+    )
   }
+}
 
-  fun byName(name: String): SolType? = registry[name]
-
-  val msgType: SolType by lazy {
-    SolStruct(psiFactory.createStruct("""
-      struct ${internalise("Msg")} {
-          bytes data;
-          uint gas;
-          address sender;
-          uint value;
-      }
-    """))
-  }
-
-  val txType: SolType by lazy {
-    SolStruct(psiFactory.createStruct("""
-      struct ${internalise("Tx")} {
-          uint gasprice;
-          address origin;
-      }
-    """))
-  }
-
-  val addressType: SolContract by lazy {
-    SolContract(psiFactory.createContract("""
-      contract ${internalise("Address")} {
-          function transfer(uint value);
-          
-          function send(uint value) returns (bool);
-      }
-    """))
-  }
-
-  val arrayType: SolContract by lazy {
-    SolContract(psiFactory.createContract("""
-      contract ${internalise("Array")} {
-          function push(uint value);
-      }
-    """))
-  }
-
-  val blockType: SolType by lazy {
-    BuiltinType(internalise("Block"), listOf(
-      BuiltinCallable(listOf(), SolAddress, "coinbase", null, Usage.VARIABLE),
-      BuiltinCallable(listOf(), UINT_256, "difficulty", null, Usage.VARIABLE),
-      BuiltinCallable(listOf(), UINT_256, "gasLimit", null, Usage.VARIABLE),
-      BuiltinCallable(listOf(), UINT_256, "number", null, Usage.VARIABLE),
-      BuiltinCallable(listOf(), UINT_256, "timestamp", null, Usage.VARIABLE),
-      BuiltinCallable(listOf("blockNumber" to UINT_256), SolFixedBytes(32), "blockhash", null, Usage.VARIABLE)
-    ))
-  }
-
-  val globalType: SolContract by lazy {
-    SolContract(psiFactory.createContract("""
-      contract Global {
-          $blockType block;
-          $msgType msg;
-          $txType tx;
-          uint now;
-
-          function assert(bool condition) private {}
-          function require(bool condition) private {}
-          function require(bool condition, string message) private {}
-          function revert() private {}
-          function revert(string) {}
-          function keccak256() returns (bytes32) private {}
-          function sha3() returns (bytes32) private {}
-          function sha256() returns (bytes32) private {}
-          function ripemd160() returns (bytes20) private {}
-          function ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) returns (address) private {}
-          function addmod(uint x, uint y, uint k) returns (uint) private {}
-          function mulmod(uint x, uint y, uint k) returns (uint) private returns (uint) {}
-          function selfdestruct(address recipient) private {};
-      }
-    """))
-  }
+fun PsiElement.isGlobal(): Boolean {
+  return this.containingFile == SolInternalTypeFactory.of(this.project).globals.file
 }

--- a/src/main/kotlin/me/serce/solidity/lang/types/types.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/types.kt
@@ -72,7 +72,7 @@ object SolAddress : SolPrimitiveType {
   override fun toString() = "address"
 
   override fun getMembers(project: Project): List<SolMember> {
-    return SolInternalTypeFactory.of(project).addressType.ref.functionDefinitionList
+    return SolInternalTypeFactory.of(project).globals.addressScope.ref.functionDefinitionList
   }
 }
 
@@ -298,7 +298,7 @@ sealed class SolArray(val type: SolType) : SolType {
     }
 
     override fun getMembers(project: Project): List<SolMember> {
-      return SolInternalTypeFactory.of(project).arrayType.ref
+      return SolInternalTypeFactory.of(project).globals.arrayScope.ref
         .functionDefinitionList
         .map {
           val parameters = it.parseParameters()

--- a/src/main/resources/builtins/solidity-0.8.15.sol
+++ b/src/main/resources/builtins/solidity-0.8.15.sol
@@ -1,0 +1,260 @@
+// https://docs.soliditylang.org/en/v0.8.15/units-and-global-variables.html
+
+abstract contract Block {
+    /**
+    Current block’s base fee (EIP-3198 and EIP-1559)
+    */
+    uint basefee;
+
+    /**
+    Current chain id
+    */
+    uint chainid;
+
+    /**
+    Current block miner’s address
+    */
+    address payable coinbase;
+
+    /**
+    Current block difficulty
+    */
+    uint difficulty;
+
+    /**
+    Current block gaslimit
+    */
+    uint gaslimit;
+
+    /**
+    Current block number
+    */
+    uint number;
+
+    /**
+    Current block timestamp as seconds since unix epoch
+    */
+    uint timestamp;
+}
+
+abstract contract Msg {
+    /**
+    Complete calldata
+    */
+    bytes data;
+
+    /**
+    Sender of the message (current call)
+    */
+    address sender;
+
+    /**
+    First four bytes of the calldata (i.e. function identifier)
+    */
+    bytes4 sig;
+
+    /**
+    Number of wei sent with the message
+    */
+    uint value;
+}
+
+abstract contract Tx {
+    /**
+    Gas price of the transaction
+    */
+    uint gasprice;
+
+    /**
+    Sender of the transaction (full call chain)
+    */
+    address origin;
+}
+
+abstract contract Abi {
+    /**
+    ABI-decodes the given data, while the types are given in parentheses as second argument.
+    Example: (uint a, uint[2] memory b, bytes memory c) = abi.decode(data, (uint, uint[2], bytes))
+    */
+    function decode(bytes memory encodedData /* , ... */) public virtual /* returns ( ... ) */;
+
+    /**
+    ABI-encodes the given arguments
+    */
+    function encode(/* ... */) public virtual returns (bytes memory);
+
+    /**
+    Performs packed encoding of the given arguments.
+    Note that packed encoding can be ambiguous!
+    */
+    function encodePacked(/* ... */) public virtual returns (bytes memory);
+
+    /**
+    ABI-encodes the given arguments starting from the second and prepends the given four-byte selector
+    */
+    function encodeWithSelector(bytes4 selector /* , ... */) public virtual returns (bytes memory);
+
+    /**
+    Equivalent to abi.encodeWithSelector(bytes4(keccak256(bytes(signature))), ...)
+    */
+    function encodeWithSignature(string memory signature /* , ... */) public virtual returns (bytes memory);
+
+    /**
+    ABI-encodes a call to functionPointer with the arguments found in the tuple.
+    Performs a full type-check, ensuring the types match the function signature.
+    Result equals abi.encodeWithSelector(functionPointer.selector, (...))
+    */
+    function encodeCall(/* function functionPointer, ... */) public virtual returns (bytes memory);
+}
+
+abstract contract Bytes {
+    /**
+    Concatenates variable number of bytes and bytes1, …, bytes32 arguments to one byte array
+    */
+    function concat(/* ... */) public virtual returns (bytes memory);
+}
+
+abstract contract String {
+    /**
+    Concatenates variable number of string arguments to one string array
+    */
+    function concat(/* ... */) public virtual returns (string memory);
+}
+
+abstract contract Array {
+    uint length;
+
+    function push(/* ... */) public virtual;
+    function pop() public virtual /* returns (...) */;
+}
+
+abstract contract Address {
+    /**
+    Balance of the Address in Wei
+    */
+    uint256 balance;
+
+    /**
+    Code at the Address (can be empty)
+    */
+    bytes code;
+
+    /**
+    The codehash of the Address
+    */
+    bytes32 codehash;
+
+    /**
+    Send given amount of Wei to Address, reverts on failure, forwards 2300 gas stipend, not adjustable
+    */
+    function transfer(uint256 amount) public virtual;
+
+    /**
+    Send given amount of Wei to Address, returns false on failure, forwards 2300 gas stipend, not adjustable
+    */
+    function send(uint256 amount) public virtual returns (bool);
+
+    /**
+    Issue low-level CALL with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    */
+    function call(bytes memory) public virtual returns (bool, bytes memory);
+
+    /**
+    Issue low-level DELEGATECALL with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    */
+    function delegatecall(bytes memory) public virtual returns (bool, bytes memory);
+
+    /**
+    Issue low-level STATICCALL with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    */
+    function staticcall(bytes memory) public virtual returns (bool, bytes memory);
+}
+
+abstract contract Globals {
+    Block block;
+    Msg msg;
+    Tx tx;
+    Abi abi;
+
+    /**
+    Hash of the given block when blocknumber is one of the 256 most recent blocks; otherwise returns zero
+    */
+    function blockhash(uint blockNumber) public virtual returns (bytes32);
+
+    /**
+    Remaining gas
+    */
+    function gasleft() public virtual returns (uint256);
+
+    /**
+    Causes a Panic error and thus state change reversion if the condition is not met - to be used for internal errors.
+    */
+    function assert(bool condition) public virtual;
+
+    /**
+    Reverts if the condition is not met - to be used for errors in inputs or external components.
+    */
+    function require(bool condition) public virtual;
+
+    /**
+    Reverts if the condition is not met - to be used for errors in inputs or external components.
+    Also provides an error message.
+    */
+    function require(bool condition, string memory message) public virtual;
+
+    /**
+    Abort execution and revert state changes
+    */
+    function revert() public virtual;
+
+    /**
+    Abort execution and revert state changes, providing an explanatory string
+    */
+    function revert(string memory reason) public virtual;
+
+    /**
+    Compute (x + y) % k where the addition is performed with arbitrary precision and does not wrap around at 2**256.
+    Assert that k != 0 starting from version 0.5.0.
+    */
+    function addmod(uint x, uint y, uint k) public virtual returns (uint);
+
+    /**
+    Compute (x * y) % k where the multiplication is performed with arbitrary precision and does not wrap around at 2**256.
+    Assert that k != 0 starting from version 0.5.0.
+    */
+    function mulmod(uint x, uint y, uint k) public virtual returns (uint);
+
+    /**
+    Compute the Keccak-256 hash of the input
+    */
+    function keccak256(bytes memory) public virtual returns (bytes32);
+
+    /**
+    Compute the SHA-256 hash of the input
+    */
+    function sha256(bytes memory) public virtual returns (bytes32);
+
+    /**
+    Compute RIPEMD-160 hash of the input
+    */
+    function ripemd160(bytes memory) public virtual returns (bytes20);
+
+    /**
+    Recover the address associated with the public key from elliptic curve signature or return zero on error.
+    The function parameters correspond to ECDSA values of the signature:
+        * r = first 32 bytes of signature
+        * s = second 32 bytes of signature
+        * v = final 1 byte of signature
+
+    ecrecover returns an address, and not an address payable.
+    See address payable (https://docs.soliditylang.org/en/v0.8.15/types.html#address) for conversion, in case you need to transfer funds to the recovered address.
+    */
+    function ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) public virtual returns (address);
+
+    /**
+    Destroy the current contract, sending its funds to the given Address and end execution. Note that selfdestruct has some peculiarities inherited from the EVM:
+      * the receiving contract's receive function is not executed.
+      * the contract is only really destroyed at the end of the transaction and revert s might "undo" the destruction.
+    */
+    function selfdestruct(address recipient) public virtual;
+}


### PR DESCRIPTION
This change replaces the types inlined in `SolInternalTypeFactory` with a bundled `.sol` file that is loaded through the PSI system.  This allows references to globals to have a destination for references, essentially providing docs in-process.

Example:

Jumping to `keccak256` in this file...
![image](https://user-images.githubusercontent.com/1980504/187587931-885bcec6-a46c-450d-8c0f-b2a639a27cff.png)

Displays the following file
![image](https://user-images.githubusercontent.com/1980504/187588025-cc6a7453-0b20-4be6-afd9-ffe94cb9df01.png)

In addition, syntax highlighting now uses the properties from the global scope in order to highlight globals, meaning they no longer need to be hard-coded in the annotator.

I've added all of the globals from [the solidity docs](https://docs.soliditylang.org/en/v0.8.15/units-and-global-variables.html) that I could find, including the array and address scopes.  This seems to work pretty well so far, but more extensive testing is probably still needed.

### TODO
- [ ] Fix tests