### PR TITLE
add remappings.txt support for foundry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.ipr
 *.iws
 gen
-lib
+/lib
 .sandbox
 .DS_Store
 /out/

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -80,10 +80,6 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
           remappings.add(Pair(splitMapping[0].trim(),splitMapping[1].trim()))
         }
       }
-    } else {
-      // add default mapping for forge-std and openzeppelin
-      remappings.add(Pair("forge-std/","lib/forge-std/src/"));
-      remappings.add(Pair("@openzeppelin/", "lib/openzeppelin-contracts/"));
     }
 
     val remappedPath = applyRemappings(remappings, path);

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -45,17 +45,54 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
     }
   }
 
-  // default lib located at: forge-std/Test.sol => lib/forge-std/src/Test.sol
-  private fun findFoundryImportFile(file: VirtualFile, path: String): VirtualFile? {
+  // apply foundry remappings to import path
+  private fun applyRemappings(remappings: ArrayList<Pair<String,String>>, path: String):String {
+    var output = path;
+    remappings.forEach { (prefix, target) ->
+      if (path.contains(prefix)) {
+        output = path.replace(prefix, target)
+        return output
+      }
+    }
+    return output;
+  }
+
+  private fun foundryDefaultFallback(file: VirtualFile, path: String): VirtualFile? {
     val count = Paths.get(path).nameCount;
-    if (count < 2) {
+    if (count<2) {
       return null;
     }
-    val libName = Paths.get(path).subpath(0, 1).toString();
-    val libFile = Paths.get(path).subpath(1, count).toString();
+    val libName = Paths.get(path).subpath(0,1).toString();
+    val libFile = Paths.get(path).subpath(1,count).toString();
     val test = file.findFileByRelativePath("lib/$libName/src/$libFile");
+    return test;
+  }
+
+  // default lib located at: forge-std/Test.sol => lib/forge-std/src/Test.sol
+  private fun findFoundryImportFile(file: VirtualFile, path: String): VirtualFile? {
+    val testRemappingFile = file.findFileByRelativePath("remappings.txt");
+    val remappings = arrayListOf<Pair<String, String>>();
+    if (testRemappingFile != null) {
+      val mappingsContents = testRemappingFile.contentsToByteArray().toString(Charsets.UTF_8).split("[\r\n]+".toRegex());
+      mappingsContents.forEach { mapping ->
+        val splitMapping = mapping.split("=")
+        if (splitMapping.size == 2) {
+          remappings.add(Pair(splitMapping[0].trim(),splitMapping[1].trim()))
+        }
+      }
+    } else {
+      // add default mapping for forge-std and openzeppelin
+      remappings.add(Pair("forge-std/","lib/forge-std/src/"));
+      remappings.add(Pair("@openzeppelin/", "lib/openzeppelin-contracts/"));
+    }
+
+    val remappedPath = applyRemappings(remappings, path);
+    val testRemappedPath = file.findFileByRelativePath(remappedPath);
+    val testFoundryFallback = foundryDefaultFallback(file, path);
+
     return when {
-      test != null -> test
+      testRemappedPath != null -> testRemappedPath
+      testFoundryFallback != null -> testFoundryFallback
       file.parent != null -> findFoundryImportFile(file.parent, path)
       else -> null
     }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveFoundryTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveFoundryTest.kt
@@ -1,0 +1,26 @@
+package me.serce.solidity.lang.core.resolve
+
+import me.serce.solidity.lang.psi.SolNamedElement
+
+class SolImportResolveFoundryTest : SolResolveTestBase() {
+
+  fun testImportPathResolveFoundryRemappings() {
+    val testcases = arrayListOf<Pair<String, String>>(
+      Pair("lib/forge-std/src/Test.sol","contracts/ImportUsageFoundryStd.sol"),
+      Pair("lib/solmate/src/tokens/ERC721.sol","contracts/ImportUsageFoundrySolmate.sol"),
+      Pair("lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol","contracts/ImportUsageFoundryOpenzeppelin.sol"),
+    );
+    testcases.forEach { (targetFile, contractFile) ->
+      val file1 = myFixture.configureByFile(targetFile)
+      myFixture.configureByFile("remappings.txt")
+      myFixture.configureByFile(contractFile)
+      val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
+      val resolved = checkNotNull(refElement.reference?.resolve()) {
+        "Failed to resolve ${refElement.text}"
+      }
+      assertEquals(file1.name, resolved.containingFile.name)
+    }
+  }
+
+  override fun getTestDataPath() = "src/test/resources/fixtures/importRemappings/"
+}

--- a/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundryOpenzeppelin.sol
+++ b/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundryOpenzeppelin.sol
@@ -1,0 +1,4 @@
+import "@openzeppelin/token/ERC20/ERC20.sol";
+       //^
+
+contract ImportUsage {}

--- a/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundrySolmate.sol
+++ b/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundrySolmate.sol
@@ -1,0 +1,4 @@
+import "@solmate/tokens/ERC721.sol";
+       //^
+
+contract ImportUsage {}

--- a/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundryStd.sol
+++ b/src/test/resources/fixtures/importRemappings/contracts/ImportUsageFoundryStd.sol
@@ -1,0 +1,4 @@
+import "forge-std/Test.sol";
+       //^
+
+contract ImportUsage {}

--- a/src/test/resources/fixtures/importRemappings/lib/forge-std/src/Test.sol
+++ b/src/test/resources/fixtures/importRemappings/lib/forge-std/src/Test.sol
@@ -1,0 +1,1 @@
+contract Test {}

--- a/src/test/resources/fixtures/importRemappings/lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol
+++ b/src/test/resources/fixtures/importRemappings/lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol
@@ -1,0 +1,1 @@
+contract ERC20 {}

--- a/src/test/resources/fixtures/importRemappings/lib/solmate/src/tokens/ERC721.sol
+++ b/src/test/resources/fixtures/importRemappings/lib/solmate/src/tokens/ERC721.sol
@@ -1,0 +1,1 @@
+contract ERC721 {}

--- a/src/test/resources/fixtures/importRemappings/remappings.txt
+++ b/src/test/resources/fixtures/importRemappings/remappings.txt
@@ -1,0 +1,3 @@
+@solmate/=lib/solmate/src/
+@openzeppelin/=lib/openzeppelin-contracts/contracts/
+


### PR DESCRIPTION
WIP for https://github.com/intellij-solidity/intellij-solidity/issues/281

https://book.getfoundry.sh/projects/dependencies.html#remapping-dependencies

This version keeps logic from https://github.com/intellij-solidity/intellij-solidity/pull/305, which can resolve the standard path ("lib/module/src") without using "remappings.txt"