### PR TITLE
fix #351: resolve resolving performance issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'https://jitpack.io'}
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -53,12 +53,10 @@ intellij {
     pluginName = 'Intellij-Solidity'
 
     version = '2022.2.5'
+    type = 'IU'
     downloadSources = true
     updateSinceUntilBuild = false
-    // TODO(sergey): remove
-    plugins = [
-        'java',
-    ]
+    plugins = ['JavaScript']
 
     sandboxDir = project.rootDir.canonicalPath + "/.sandbox"
 }

--- a/src/main/kotlin/me/serce/solidity/ide/navigation/goto.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/navigation/goto.kt
@@ -39,7 +39,7 @@ abstract class SolNavigationContributorBase<T>(
     return StubIndex.getElements(indexKey, name, project, scope, clazz).toTypedArray<NavigationItem>()
   }
 
-  override fun getQualifiedName(item: NavigationItem?): String? = item?.name
+  override fun getQualifiedName(item: NavigationItem): String? = item.name
 
   override fun getQualifiedNameSeparator(): String = "."
 }

--- a/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
@@ -357,7 +357,7 @@ abstract class SolUserDefinedTypeNameImplMixin : SolStubbedElementImpl<SolTypeRe
   override fun getReference(): SolReference = SolUserDefinedTypeNameReference(this)
 
   override val referenceNameElement: PsiElement
-    get() = findChildByType(IDENTIFIER)!!
+    get() = findIdentifiers().last()
 
   override fun findIdentifiers(): List<PsiElement> =
     findChildrenByType(IDENTIFIER)

--- a/src/main/kotlin/me/serce/solidity/lang/stubs/jsindexing/SolNodeModulesIndexableFileNamesProvider.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/stubs/jsindexing/SolNodeModulesIndexableFileNamesProvider.kt
@@ -1,0 +1,12 @@
+package me.serce.solidity.lang.stubs.jsindexing
+
+import com.intellij.lang.javascript.modules.NodeModulesIndexableFileNamesProvider
+
+/**
+ * IDEs supporting JavaScript (WebStorm, IJ Ultimate, etc.) automatically exclude node_modules folders from indexing
+ * except for a certain set of files which breaks resolving and anything else that relies on indexes. To combat this
+ * behaviour, we explicitly register Solidity files to be indexed.
+ */
+class SolNodeModulesIndexableFileNamesProvider : NodeModulesIndexableFileNamesProvider() {
+  override fun getIndexableExtensions(kind: DependencyKind): List<String> = listOf(".sol")
+}

--- a/src/main/resources/META-INF/javascriptPlugin.xml
+++ b/src/main/resources/META-INF/javascriptPlugin.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="JavaScript">
+        <nodeModulesIndexableFileNamesProvider
+                implementation="me.serce.solidity.lang.stubs.jsindexing.SolNodeModulesIndexableFileNamesProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -51,11 +51,16 @@
     -->
     <idea-version since-build="222.4554.10"/>
 
+    <!-- See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html for the full list of modules -->
     <depends>com.intellij.modules.lang</depends>
-    <!-- TODO -->
+    <!--
+        The below might not be strictly necessary, however, it's required as per
+        https://plugins.jetbrains.com/docs/intellij/webstorm.html#configuring-plugin-projects-targeting-webstorm
+        in order to include JavaScript.
+    -->
     <depends>com.intellij.modules.platform</depends>
-    <!-- TODO -->
-    <depends optional="true" config-file="javascriptPlugin.xml">JavaScript</depends>=
+    <!-- The dependency is necessary because JavaScript-aware IDEs exclude node_modules by default. -->
+    <depends optional="true" config-file="javascriptPlugin.xml">JavaScript</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="Solidity file"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,10 @@
     <idea-version since-build="222.4554.10"/>
 
     <depends>com.intellij.modules.lang</depends>
+    <!-- TODO -->
+    <depends>com.intellij.modules.platform</depends>
+    <!-- TODO -->
+    <depends optional="true" config-file="javascriptPlugin.xml">JavaScript</depends>=
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="Solidity file"


### PR DESCRIPTION
This commit rewrites import-aware resolving to ensure that index is always used. The previous version would often result in long recursive lookups that ignore index completely. The issues are visible on the flame graph below. 

<img width="1382" alt="Screenshot 2023-03-31 at 5 48 06 pm" src="https://user-images.githubusercontent.com/1780970/229044450-c1c7cf01-5623-4b78-9df0-76c43b6874f9.png">

The reimplement version also relies on fully-lazy declaration search which was previously eager in some cases to avoid infinite recursion on import resolution. The previous use of `nullIfError` would also sometimes result in jobs running for longer than necessary due to ignoring ProgressInterrupted exceptions. 

