### PR TITLE
resolve IAE on type inference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,6 @@ runIde {
 
 repositories {
     mavenCentral()
-    // ethereumj isn't available on maven central
-    jcenter()
     maven { url "https://www.jetbrains.com/intellij-repository/releases" }
     maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
 }

--- a/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/inference.kt
@@ -88,8 +88,8 @@ fun inferDeclType(decl: SolNamedElement): SolType {
       val def = list.findParent<SolVariableDefinition>()
       val inferred = inferExprType(def.expression)
       val index = list.declarationItemList.indexOf(decl)
-      when (inferred) {
-        is SolTuple -> inferred.types[index]
+      when (inferred is SolTuple && index < inferred.types.size) {
+        true -> inferred.types[index]
         else -> SolUnknown
       }
     }


### PR DESCRIPTION
Resolve the below error which is triggered with tuples. Although, this does resolve the root cause, it removes the annoying error reporting. To remove the root cause an overhaul of the whole inference system is needed. 

```
java.lang.IndexOutOfBoundsException: Index 3 out of bounds for length 2
    at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
    at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
    at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
    at java.util.Objects.checkIndex(Objects.java:359)
    at java.util.ArrayList.get(ArrayList.java:427)
    at me.serce.solidity.lang.types.InferenceKt.inferDeclType(inference.kt:92)
    at me.serce.solidity.lang.types.InferenceKt$inferRefType$2.invoke(inference.kt:125)
```