### PR TITLE
remove usages of deprecated classes

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/annotation/SolidityLineMarkerProvider.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/SolidityLineMarkerProvider.kt
@@ -31,7 +31,7 @@ class SolidityLineMarkerProvider : LineMarkerProvider {
               val info = NavigationGutterIconBuilder
                 .create(AllIcons.Gutter.OverridenMethod)
                 .setTargets(el.findAllImplementations())
-                .setPopupTitle("Go to implementation")
+                .setPopupTitle("Go To Implementation")
                 .setTooltipText("Has implementations")
                 .createLineMarkerInfo(identifier)
               result.add(info)
@@ -46,9 +46,9 @@ class SolidityLineMarkerProvider : LineMarkerProvider {
               val info = NavigationGutterIconBuilder
                 .create(AllIcons.Gutter.OverridingMethod)
                 .setTargets(overriden)
-                .setPopupTitle("Go to overriden functions")
+                .setPopupTitle("Go To Overridden Functions")
                 .setTooltipText("Overrides function")
-                .setCellRenderer(FunctionCellRenderer(el.containingFile))
+                .setCellRenderer { FunctionCellRenderer(el.containingFile) }
                 .createLineMarkerInfo(identifier)
               result.add(info)
             }
@@ -57,9 +57,9 @@ class SolidityLineMarkerProvider : LineMarkerProvider {
               val info = NavigationGutterIconBuilder
                 .create(AllIcons.Gutter.OverridenMethod)
                 .setTargets(overrides)
-                .setPopupTitle("Is overriden")
-                .setTooltipText("Is overriden in subcontracts")
-                .setCellRenderer(FunctionCellRenderer(el.containingFile))
+                .setPopupTitle("Is Overridden")
+                .setTooltipText("Is overridden in subcontracts")
+                .setCellRenderer { FunctionCellRenderer(el.containingFile) }
                 .createLineMarkerInfo(identifier)
               result.add(info)
             }

--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
@@ -3,7 +3,6 @@ package me.serce.solidity.ide.formatting
 import com.intellij.formatting.*
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.codeStyle.CodeStyleSettings
 import com.intellij.psi.tree.TokenSet
@@ -17,7 +16,9 @@ import me.serce.solidity.lang.core.SolidityTokenTypes.*
  * https://github.com/ethereum/solidity/blob/develop/docs/style-guide.rst
  */
 class SolidityFormattingModelBuilder : FormattingModelBuilder {
-  override fun createModel(element: PsiElement, settings: CodeStyleSettings): FormattingModel {
+  override fun createModel(context: FormattingContext): FormattingModel {
+    val element = context.psiElement
+    val settings = context.codeStyleSettings
     val spacingBuilder = createSpacingBuilder(settings)
 
     val containingFile = element.containingFile

--- a/src/main/kotlin/me/serce/solidity/ide/formatting/settings.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/settings.kt
@@ -14,7 +14,7 @@ class SolCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
 
   override fun getConfigurableDisplayName() = SolidityLanguage.displayName
 
-  override fun createSettingsPage(settings: CodeStyleSettings, originalSettings: CodeStyleSettings) =
+  override fun createConfigurable(settings: CodeStyleSettings, originalSettings: CodeStyleSettings) =
     object : CodeStyleAbstractConfigurable(settings, originalSettings, configurableDisplayName) {
       override fun createPanel(settings: CodeStyleSettings) = SolCodeStyleMainPanel(currentSettings, settings)
       override fun getHelpTopic() = null
@@ -40,10 +40,10 @@ class SolLanguageCodeStyleSettingsProvider : LanguageCodeStyleSettingsProvider()
       else -> ""
     }
 
-  override fun getDefaultCommonSettings(): CommonCodeStyleSettings {
-    val settings = CommonCodeStyleSettings(SolidityLanguage)
-    settings.initIndentOptions()
-    return settings
+  override fun customizeDefaults(
+    commonSettings: CommonCodeStyleSettings,
+    indentOptions: CommonCodeStyleSettings.IndentOptions
+  ) {
   }
 
   override fun getIndentOptionsEditor(): IndentOptionsEditor? = SmartIndentOptionsEditor()

--- a/src/main/kotlin/me/serce/solidity/ide/hints/SolDocumentationProvider.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/hints/SolDocumentationProvider.kt
@@ -55,7 +55,7 @@ class SolDocumentationProvider : AbstractDocumentationProvider() {
     return builder.toString()
   }
 
-  private val keywordColors = SolHighlighter.keywords().plus(SolHighlighter.types()).filterNot { it == SolidityTokenTypes.RETURN }.map { it.debugName }
+  private val keywordColors = SolHighlighter.keywords().plus(SolHighlighter.types()).filterNot { it == SolidityTokenTypes.RETURN }.map { it.toString()   }
     .plus(setOf("u?int(\\d+)", "u?fixed(\\d+)", "bytes?(\\d+)"))
     .joinToString("|", "\\b(", ")\\b").toRegex()
   private val col = SolColor.TYPE.textAttributesKey.defaultAttributes.foregroundColor

--- a/src/main/kotlin/me/serce/solidity/ide/hints/SolParameterInfoHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/hints/SolParameterInfoHandler.kt
@@ -1,7 +1,5 @@
 package me.serce.solidity.ide.hints
 
-import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.lang.parameterInfo.ParameterInfoContext
 import com.intellij.lang.parameterInfo.ParameterInfoUIContext
 import com.intellij.lang.parameterInfo.ParameterInfoUtils
 import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
@@ -16,10 +14,6 @@ import me.serce.solidity.lang.resolve.ref.SolFunctionCallReference
 import me.serce.solidity.lang.types.findParentOrNull
 
 class SolParameterInfoHandler : AbstractParameterInfoHandler<SolFunctionCallExpression, SolArgumentsDescription>() {
-  override fun couldShowInLookup() = true
-
-  override fun getParametersForLookup(item: LookupElement, context: ParameterInfoContext?): Array<out Any>? = null
-
   override fun findTargetElement(file: PsiFile, offset: Int): SolFunctionCallExpression? {
     return file.findElementAt(offset)?.findParentOrNull()
   }
@@ -54,13 +48,6 @@ class SolParameterInfoHandler : AbstractParameterInfoHandler<SolFunctionCallExpr
       false,
       if (p.valid) context.defaultParameterColor.brighter() else context.defaultParameterColor)
   }
-
-  override fun getParameterCloseChars() = ",)"
-
-  override fun tracksParameterIndex() = true
-
-  override fun getParametersForDocumentation(p: SolArgumentsDescription, context: ParameterInfoContext?) =
-    p.arguments
 }
 
 class SolArgumentsDescription(

--- a/src/main/kotlin/me/serce/solidity/lang/core/parser.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/core/parser.kt
@@ -21,7 +21,7 @@ class SolidityParserDefinition : ParserDefinition {
 
   override fun createFile(viewProvider: FileViewProvider): PsiFile = SolidityFile(viewProvider)
 
-  override fun spaceExistanceTypeBetweenTokens(left: ASTNode, right: ASTNode): ParserDefinition.SpaceRequirements =
+  override fun spaceExistenceTypeBetweenTokens(left: ASTNode, right: ASTNode): ParserDefinition.SpaceRequirements =
     LanguageUtil.canStickTokensTogetherByLexer(left, right, SolidityLexer())
 
   override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY

--- a/src/main/kotlin/me/serce/solidity/lang/psi/factory.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/factory.kt
@@ -28,7 +28,7 @@ class SolPsiFactory(val project: Project) {
   }
 
   fun createNewLine(project: Project): PsiElement {
-    return PsiParserFacade.SERVICE.getInstance(project).createWhiteSpaceFromText("\n")
+    return PsiParserFacade.getInstance(project).createWhiteSpaceFromText("\n")
   }
 
   fun createContract(@Language("Solidity") contractBody: String): SolContractDefinition {

--- a/src/main/kotlin/me/serce/solidity/lang/types/internal.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/internal.kt
@@ -1,6 +1,5 @@
 package me.serce.solidity.lang.types
 
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import me.serce.solidity.lang.psi.SolPsiFactory
 import org.intellij.lang.annotations.Language
@@ -10,7 +9,7 @@ class SolInternalTypeFactory(project: Project) {
 
   companion object {
     fun of(project: Project): SolInternalTypeFactory {
-      return ServiceManager.getService(project, SolInternalTypeFactory::class.java)
+      return project.getService(SolInternalTypeFactory::class.java)
     }
   }
 


### PR DESCRIPTION
The latest release came with the following report. The usages of deprecated classes are likely to break the plugin in future versions. This PR resolves the highlighted issues. 
<img width="1221" alt="Screenshot 2023-04-02 at 1 50 59 pm" src="https://user-images.githubusercontent.com/1780970/229330333-77e3a8fd-0807-48f3-b07a-0ef1476ef875.png">
