### PR TITLE
support for move refactoring

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/refactoring/SolMoveHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/refactoring/SolMoveHandler.kt
@@ -1,0 +1,24 @@
+package me.serce.solidity.ide.refactoring
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.refactoring.move.MoveCallback
+import com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesHandler
+
+class SolMoveHandler : MoveFilesOrDirectoriesHandler() {
+  override fun doMove(project: Project?, elements: Array<out PsiElement>, targetContainer: PsiElement?, callback: MoveCallback?) {
+    val oldRefs = mutableMapOf<String, MutableList<PsiReference>>()
+    elements.forEach { oldFile ->
+      ReferencesSearch.search(oldFile).forEach {ref ->  oldFile.containingFile?.let { oldRefs.getOrPut(it.name) { mutableListOf() }.add(ref) } }
+    }
+
+    super.doMove(project, elements, targetContainer) {
+      callback?.refactoringCompleted()
+      elements.forEach {newFile ->
+        oldRefs[newFile.containingFile.name]?.forEach { it.bindToElement(newFile) }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/me/serce/solidity/ide/refactoring/SolRenameFileProcessor.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/refactoring/SolRenameFileProcessor.kt
@@ -1,0 +1,24 @@
+package me.serce.solidity.ide.refactoring
+
+import com.intellij.openapi.ui.MessageDialogBuilder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.SearchScope
+import com.intellij.refactoring.rename.RenamePsiFileProcessor
+import me.serce.solidity.lang.core.SolidityFile
+import me.serce.solidity.lang.psi.SolContractOrLibElement
+
+class SolRenameFileProcessor : RenamePsiFileProcessor() {
+  override fun prepareRenaming(element: PsiElement, newName: String, allRenames: MutableMap<PsiElement, String>, scope: SearchScope) {
+    (element as? SolidityFile)?.let { file ->
+      val contract = file.children.find { it is SolContractOrLibElement && it.name == file.virtualFile.nameWithoutExtension && it.name != newName } as? SolContractOrLibElement
+      if (contract != null) {
+        val description = contract.contractType.docName
+        val renameContract = /*!RefactoringSettings.getInstance().ASK_FOR_RENAME_DECLARATION_WHEN_RENAME_FILE ||*/ MessageDialogBuilder.yesNo("Rename $description", "Do you also want to rename the $description").ask(element.getProject())
+        if (renameContract) {
+          allRenames[contract] = newName
+        }
+      }
+    }
+    super.prepareRenaming(element, newName, allRenames, scope)
+  }
+}

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.source.tree.LeafElement
+import me.serce.solidity.ide.inspections.fixes.ImportFileAction
 import me.serce.solidity.lang.core.SolidityFile
 import me.serce.solidity.lang.psi.impl.SolImportPathElement
 import java.nio.file.Paths;
@@ -120,5 +121,12 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
     }
     val newImportPath = currentPath.replace(name, newName)
     identifier.replaceWithText(newImportPath)
+  }
+
+  override fun bindToElement(element: PsiElement): PsiElement {
+    val file = element as? SolidityFile ?: return element
+    val newPath = ImportFileAction.buildImportPath(this.element.containingFile.virtualFile, file.virtualFile)
+    val identifier = this.element.referenceNameElement as? LeafElement ?: return element
+    return identifier.replaceWithText("\"$newPath\"").psi ?: element
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,6 +86,9 @@
 
         <renamePsiElementProcessor implementation="me.serce.solidity.ide.refactoring.RenameContractProcessor"/>
         <renamePsiElementProcessor implementation="me.serce.solidity.ide.refactoring.RenameConstructorProcessor"/>
+        <renamePsiElementProcessor implementation="me.serce.solidity.ide.refactoring.SolRenameFileProcessor"/>
+        <refactoring.moveHandler implementation="me.serce.solidity.ide.refactoring.SolMoveHandler" order="first"/>
+
 
         <!-- Commenter -->
         <lang.commenter language="Solidity" implementationClass="me.serce.solidity.ide.SolCommenter"/>

--- a/src/test/resources/fixtures/refactoring/rename/imports/Lab.sol
+++ b/src/test/resources/fixtures/refactoring/rename/imports/Lab.sol
@@ -1,1 +1,1 @@
-contract Lab {}
+contract Lab1 {}

--- a/src/test/resources/fixtures/refactoring/rename/imports/nested/ImportingFile.sol
+++ b/src/test/resources/fixtures/refactoring/rename/imports/nested/ImportingFile.sol
@@ -1,5 +1,5 @@
 import "../Lab.sol";
 
 contract IUseLab {
-  Lab lab;
+  Lab1 lab;
 }

--- a/src/test/resources/fixtures/refactoring/rename/imports/nested/ImportingFile_after.sol
+++ b/src/test/resources/fixtures/refactoring/rename/imports/nested/ImportingFile_after.sol
@@ -1,5 +1,5 @@
 import "../AssetGatewayToken.sol";
 
 contract IUseLab {
-  Lab lab;
+  Lab1 lab;
 }


### PR DESCRIPTION
1. suggest changing the contract name when the file name going to rename 
2. update imports inside files that depend on this file when the file was renamed or moved