### PR TITLE
Fix: lexer should properly analyze comments followed by EOF

### DIFF
--- a/src/main/grammars/_SolidityLexer.flex
+++ b/src/main/grammars/_SolidityLexer.flex
@@ -36,7 +36,6 @@ EOL=\R
 
 WHITE_SPACE=\s+
 
-EOL_COMMENT="/""/"[^\n]*
 // see https://docs.soliditylang.org/en/v0.8.7/natspec-format.html for NatSpec tags support
 NAT_SPEC_TAG=@[a-zA-Z_0-9:]*
 HEXLITERAL=(hex\"([_0-9a-fA-F]+)\"|hex\'([_0-9a-fA-F]+)\')
@@ -232,7 +231,10 @@ PRAGMAALL=[^ ][^;]*
                             return COMMENT;
                           }
 
-  <<EOF>>                 { yybegin(YYINITIAL); }
+  <<EOF>>                 {
+                            yybegin(YYINITIAL);
+                            return COMMENT;
+                          }
 
   [^]                     { }
 }
@@ -257,6 +259,11 @@ PRAGMAALL=[^ ][^;]*
                             yybegin(YYINITIAL);
                             // do not include '\n' in the comment
                             yypushback(1);
+                            return COMMENT;
+                          }
+
+  <<EOF>>                 {
+                            yybegin(YYINITIAL);
                             return COMMENT;
                           }
 


### PR DESCRIPTION
Fix for a bug I encountered while working with the plugin:

### Steps to reproduce
1. Create an empty ".sol" file
2. Start editing the file. Enter "//" (make sure no new line entered by auto-formatting, IDE options, etc.)

### Expected behavior
"//" highlight as comment.

### Actual behavior
No highlighting for "//".
Also some errors thrown (there are multiple types of errors might be shown, posting only one example):
```
com.intellij.diagnostic.PluginException: commitDocument() left PSI inconsistent: not committed document DocumentImpl[file:///home/user/solidity/T3.sol], File[Solidity File T3.sol, Language: Solidity, com.intellij.psi.SingleRootFileViewProvider{vFile=file:///home/user/solidity/T3.sol, vFileId=51820, content=com.intellij.psi.AbstractFileViewProvider$PsiFileContent@1b6b2b7e, eventSystemEnabled=true}]; node.length=0; doc.text!=file.text; file name:T3.sol; type:me.serce.solidity.lang.SolidityFileType@41d04fa1; lang:Language: Solidity [Plugin: me.serce.solidity]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:83)
	at com.intellij.diagnostic.PluginException.logPluginError(PluginException.java:100)
	at com.intellij.psi.impl.DocumentCommitThread.assertAfterCommit(DocumentCommitThread.java:317)
	at com.intellij.psi.impl.DocumentCommitThread.lambda$doCommit$5(DocumentCommitThread.java:300)
	at com.intellij.psi.impl.PsiDocumentManagerBase.commitToExistingPsi(PsiDocumentManagerBase.java:422)
	at com.intellij.psi.impl.PsiDocumentManagerBase.lambda$finishCommitInWriteAction$5(PsiDocumentManagerBase.java:396)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:683)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:639)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeInNonCancelableSection(CoreProgressManager.java:238)
	at com.intellij.psi.impl.PsiDocumentManagerBase.lambda$finishCommitInWriteAction$6(PsiDocumentManagerBase.java:391)
	at com.intellij.psi.impl.PsiDocumentManagerBase.executeInsideCommit(PsiDocumentManagerBase.java:507)
	at com.intellij.psi.impl.PsiDocumentManagerBase.finishCommitInWriteAction(PsiDocumentManagerBase.java:389)
	at com.intellij.psi.impl.PsiDocumentManagerImpl.finishCommitInWriteAction(PsiDocumentManagerImpl.java:125)
	at com.intellij.psi.impl.PsiDocumentManagerBase$2.run(PsiDocumentManagerBase.java:356)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:1023)
	at com.intellij.psi.impl.PsiDocumentManagerBase.finishCommit(PsiDocumentManagerBase.java:353)
	at com.intellij.psi.impl.DocumentCommitThread.lambda$commitUnderProgress$2(DocumentCommitThread.java:138)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$safeTransferToEdt$6(NonBlockingReadActionImpl.java:596)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:209)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:191)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:513)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:75)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:118)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:42)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:779)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:730)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:724)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:749)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:918)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:766)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:791)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:449)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:624)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:447)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:493)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

```

### Solution
Update the lexer grammar to match comments followed by EOF.
Example of how it handled in Kotlin: [Kotlin.flex](https://github.com/JetBrains/kotlin/blob/420b6d48c34dbff945196608184c2f794629ba22/compiler/psi/src/org/jetbrains/kotlin/lexer/Kotlin.flex#L199)

### Notes
This also happens with multi-line comments (by typing "/*" instead of "//").
Can be reproduced with existing files as well. The only condition is - a comment should be followed by EOF(no new line("\n") after comment.

Perhaps this bug was introduced in #247.

Seems like this fix also resolves #387 and #348 (no exact steps in the mentioned issues, so I tested on provided examples).

`EOL_COMMENT` removed because seems to be obsolete.