### PR TITLE
Named Imports & Forge Remappings

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/inspections/fixes/ImportFileFix.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/inspections/fixes/ImportFileFix.kt
@@ -24,9 +24,10 @@ class ImportFileFix(element: SolUserDefinedTypeName) : LocalQuickFixOnPsiElement
       val suggestions = SolResolver.resolveTypeName(element).map { it.containingFile }.toSet()
       val fixText: String? = when {
           suggestions.size == 1 -> {
-            val importPath = buildImportPath(element.containingFile.virtualFile, suggestions.first().virtualFile)
+            val importPath = buildImportPath(element.project, element.containingFile.virtualFile, suggestions.first().virtualFile)
             "$familyName $importPath"
           }
+
           suggestions.isNotEmpty() -> familyName
           else -> null
       }
@@ -37,6 +38,7 @@ class ImportFileFix(element: SolUserDefinedTypeName) : LocalQuickFixOnPsiElement
           )
           true
         }
+
         else -> false
       }
     } else {
@@ -47,11 +49,12 @@ class ImportFileFix(element: SolUserDefinedTypeName) : LocalQuickFixOnPsiElement
   override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
     val element = startElement as SolUserDefinedTypeName?
     return when {
-        element != null -> when {
-            !element.isValid || element.reference?.resolve() != null -> false
-            else -> SolResolver.resolveTypeName(element).isNotEmpty()
-        }
-        else -> false
+      element != null -> when {
+        !element.isValid || element.reference?.resolve() != null -> false
+        else -> SolResolver.resolveTypeName(element).isNotEmpty()
+      }
+
+      else -> false
     }
   }
 

--- a/src/main/kotlin/me/serce/solidity/lang/completion/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/engine.kt
@@ -132,7 +132,7 @@ class ContractLookupElement(val contract: SolContractDefinition) : LookupElement
 
   override fun handleInsert(context: InsertionContext) {
     if (!ImportFileAction.isImportedAlready(context.file, contract.containingFile)) {
-      ImportFileAction.addImport(contract.project, context.file, contract.containingFile)
+      ImportFileAction.addContractImport(contract, context.file)
     }
   }
 }

--- a/src/main/kotlin/me/serce/solidity/lang/psi/factory.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/factory.kt
@@ -25,6 +25,11 @@ class SolPsiFactory(val project: Project) {
       ?: error("Failed to create struct: `$structBody`")
   }
 
+  fun createContractImportFromDirective(importPath: String, contractName: String): SolImportDirective {
+    return createFromText("import {$contractName} from \"$importPath\";")
+      ?: error("Failed to create struct: `$importPath`")
+  }
+
   fun createImportDirective(importPath: String): SolImportDirective {
     return createFromText("import \"$importPath\";")
       ?: error("Failed to create struct: `$importPath`")

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -125,7 +125,7 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
 
   override fun bindToElement(element: PsiElement): PsiElement {
     val file = element as? SolidityFile ?: return element
-    val newPath = ImportFileAction.buildImportPath(this.element.containingFile.virtualFile, file.virtualFile)
+    val newPath = ImportFileAction.buildImportPath(element.project, this.element.containingFile.virtualFile, file.virtualFile)
     val identifier = this.element.referenceNameElement as? LeafElement ?: return element
     return identifier.replaceWithText("\"$newPath\"").psi ?: element
   }

--- a/src/test/kotlin/me/serce/solidity/lang/completion/SolIdentifierCompletionTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/SolIdentifierCompletionTest.kt
@@ -23,7 +23,7 @@ class SolIdentifierCompletionTest : SolCompletionTestBase() {
 
     contract A is tes/*caret*/{}""").withCaret()
     myFixture.completeBasic()
-    myFixture.checkResult("""import "./test.sol";
+    myFixture.checkResult("""import {test} from "./test.sol";
 
 contract A is test{}""")
   }
@@ -48,7 +48,7 @@ contract A is test{}""")
 
     myFixture.completeBasic()
     checkResult("""import "./rec1.sol";
-import "./test.sol";
+import {test} from "./test.sol";
 
 contract A is test{}""")
   }


### PR DESCRIPTION
Instead of auto-importing the whole file, it now imports {ContractName} from file;

In Foundry projects, In case that a `remappings.txt` file exists, it does the auto-import while respecting the [remappings.txt](https://book.getfoundry.sh/projects/dependencies?highlight=remappings.txt#remapping-dependencies) file.

Here's a gif demonstrating it:
![output](https://github.com/intellij-solidity/intellij-solidity/assets/10492324/a63d0936-1b10-45eb-a354-1eb8a0e8446a)
