### PR TITLE
fix NPE when moving files

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/refactoring/SolMoveHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/refactoring/SolMoveHandler.kt
@@ -2,6 +2,7 @@ package me.serce.solidity.ide.refactoring
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.refactoring.move.MoveCallback
@@ -17,7 +18,10 @@ class SolMoveHandler : MoveFilesOrDirectoriesHandler() {
     super.doMove(project, elements, targetContainer) {
       callback?.refactoringCompleted()
       elements.forEach {newFile ->
-        oldRefs[newFile.containingFile.name]?.forEach { it.bindToElement(newFile) }
+        val containingFile: PsiFile? = newFile.containingFile
+        if (containingFile != null) {
+          oldRefs[containingFile.name]?.forEach { it.bindToElement(newFile) }
+        }
       }
     }
   }


### PR DESCRIPTION
The change fixes
```
java.lang.NullPointerException: Cannot invoke "com.intellij.psi.PsiFile.getName()" because the return value of "com.intellij.psi.PsiElement.getContainingFile()" is null
    at me.serce.solidity.ide.refactoring.SolMoveHandler.doMove$lambda$6(SolMoveHandler.kt:20)
    at com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesProcessor.afterMove(MoveFilesOrDirectoriesProcessor.java:297)
    at com.intellij.refactoring.move.moveFilesOrDirectories.MoveFilesOrDirectoriesProcessor.performRefactoringInBranch(MoveFilesOrDirectoriesProcessor.java:265)

```