### PR TITLE
infer: do not fail on parsing hex strings with underscores

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/types/types.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/types.kt
@@ -128,7 +128,10 @@ data class SolInteger(val unsigned: Boolean, val size: Int, val digitCount: Int?
     }
 
     fun inferType(numberLiteral: SolHexLiteral): SolInteger {
-      val withoutPrefix = numberLiteral.text.substring(3).removeSurrounding("\"").removeSurrounding("'")
+      val withoutPrefix = numberLiteral.text.substring(3) //
+        .removeSurrounding("\"") //
+        .removeSurrounding("'") //
+        .replace("_", "") // underscore is an allowed separator in hex literals
       val parse = LiteralParseResult(withoutPrefix.toBigInteger(16), NumericLiteralType.HEX, withoutPrefix.length)
       return inferIntegerType(parse)
     }


### PR DESCRIPTION
This PR fixes the following error which I noticed during the pre-release round of testing. 

```
Caused by: java.lang.NumberFormatException: For input string: "60_0" under radix 16
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:668)
	at java.base/java.math.BigInteger.<init>(BigInteger.java:538)
	at me.serce.solidity.lang.types.SolInteger$Companion.inferType(types.kt:135)
	at me.serce.solidity.lang.types.InferenceKt.inferExprType(inference.kt:170)
	at me.serce.solidity.lang.types.InferenceKt._get_type_$lambda$20$lambda$19(inference.kt:259)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)

...
```

It's a bit tricky to write a test because our current inference for hex literals isn't correct as it gets inferred in the same way as a number. 