### PR TITLE
resolve: fix a SOE on imports with the same name

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -149,10 +149,17 @@ object SolResolver {
     }
   }
 
+  fun collectImports(imports: Collection<SolImportDirective>): Collection<ImportRecord> {
+    return RecursionManager.doPreventingRecursion(imports, true) {
+      val visited: MutableSet<PsiFile> = hashSetOf()
+      collectImports(imports, visited)
+    } ?: emptySet()
+  }
+
   /**
    * Collects imports of all declarations for a given file recursively.
    */
-  private fun collectImports(imports: Collection<SolImportDirective>, visited: MutableSet<PsiFile> = hashSetOf()): Collection<ImportRecord> {
+  private fun collectImports(imports: Collection<SolImportDirective>, visited: MutableSet<PsiFile>): Collection<ImportRecord> {
     if (!visited.add((imports.firstOrNull() ?: return emptyList()).containingFile)) {
       return emptySet()
     }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveTest.kt
@@ -80,6 +80,20 @@ class SolImportResolveTest : SolResolveTestBase() {
     assertEquals("abc", resolved.name)
   }
 
+  fun testRecursiveImport() {
+    myFixture.configureByFile("recursive/B.sol")
+    myFixture.configureByFile("recursive/C.sol")
+    myFixture.configureByFile("recursive/dir/C.sol")
+    myFixture.configureByFile("recursive/A.sol")
+    val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
+
+    val resolved = checkNotNull(refElement.reference?.resolve() as? PsiNamedElement) {
+      "Failed to resolve ${refElement.text}"
+    }
+
+    assertEquals("C", resolved.name)
+  }
+
   fun testResolveFrom() {
     val file1 = InlineFile(
       code = "contract A {}",

--- a/src/test/resources/fixtures/import/recursive/A.sol
+++ b/src/test/resources/fixtures/import/recursive/A.sol
@@ -1,0 +1,5 @@
+import "./B.sol";
+
+interface A is C {
+             //^
+}

--- a/src/test/resources/fixtures/import/recursive/B.sol
+++ b/src/test/resources/fixtures/import/recursive/B.sol
@@ -1,0 +1,5 @@
+import "./A.sol";
+import "./C.sol";
+
+library B {
+}

--- a/src/test/resources/fixtures/import/recursive/C.sol
+++ b/src/test/resources/fixtures/import/recursive/C.sol
@@ -1,0 +1,2 @@
+interface C {
+}

--- a/src/test/resources/fixtures/import/recursive/dir/C.sol
+++ b/src/test/resources/fixtures/import/recursive/dir/C.sol
@@ -1,0 +1,2 @@
+interface C {
+}


### PR DESCRIPTION
The PR fixes the issue raise in https://github.com/intellij-solidity/intellij-solidity/issues/447. 

Without the guard, the test fails with the following exception.
```
java.lang.StackOverflowError
	at java.base/java.lang.RuntimeException.<init>(RuntimeException.java:97)
	at com.intellij.util.containers.ConcurrentLongObjectHashMap.tabAt(ConcurrentLongObjectHashMap.java:240)
	at com.intellij.util.containers.ConcurrentLongObjectHashMap.get(ConcurrentLongObjectHashMap.java:431)
	at com.intellij.openapi.progress.impl.CoreProgressManager.getCurrentIndicator(CoreProgressManager.java:955)
	at com.intellij.openapi.progress.impl.CoreProgressManager.getProgressIndicator(CoreProgressManager.java:597)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.awaitWithCheckCanceled(ProgressIndicatorUtils.java:324)
	at com.intellij.util.indexing.RegisteredIndexes.await(RegisteredIndexes.java:190)
	at com.intellij.util.indexing.RegisteredIndexes.waitUntilIndicesAreInitialized(RegisteredIndexes.java:86)
	at com.intellij.util.indexing.FileBasedIndexImpl.waitUntilIndicesAreInitialized(FileBasedIndexImpl.java:435)
	at com.intellij.util.indexing.events.ChangedFilesCollector.ensureUpToDate(ChangedFilesCollector.java:187)
	at com.intellij.util.indexing.FileBasedIndexImpl.ensureUpToDate(FileBasedIndexImpl.java:836)
	at com.intellij.psi.stubs.StubIndexEx.getContainingIds(StubIndexEx.java:365)
	at com.intellij.psi.stubs.StubIndexEx.processElements(StubIndexEx.java:166)
	at com.intellij.psi.stubs.StubIndex.getElements(StubIndex.java:102)
	at com.intellij.psi.stubs.StubIndex.getElements(StubIndex.java:90)
	at me.serce.solidity.lang.resolve.SolResolver.resolveTypeName(engine.kt:262)
	at me.serce.solidity.lang.resolve.SolResolver.resolveTypeNameStrict(engine.kt:271)
	at me.serce.solidity.lang.resolve.SolResolver.resolveContractMembers(engine.kt:371)
	at me.serce.solidity.lang.resolve.SolResolver.resolveContractMembers$default(engine.kt:362)
	at me.serce.solidity.lang.resolve.SolResolver.collectImports(engine.kt:175)
	at me.serce.solidity.lang.resolve.SolResolver.collectImports(engine.kt:181)
	at me.serce.solidity.lang.resolve.SolResolver.collectImports(engine.kt:155)
	at me.serce.solidity.lang.resolve.SolResolver.collectImports(engine.kt:84)
	at me.serce.solidity.lang.resolve.SolResolver.resolveUsingImports(engine.kt:67)
	at me.serce.solidity.lang.resolve.SolResolver.resolveContract(engine.kt:185)
	at me.serce.solidity.lang.resolve.SolResolver.resolveTypeNameUsingImports$lambda$0(engine.kt:33)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:244)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:244)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:247)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:69)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:121)
	at me.serce.solidity.lang.resolve.SolResolver.resolveTypeNameUsingImports(engine.kt:25)
	at me.serce.solidity.lang.resolve.SolResolver.resolveTypeNameStrict(engine.kt:272)
	at me.serce.solidity.lang.resolve.SolResolver.resolveContractMembers(engine.kt:371)
	at me.serce.solidity.lang.resolve.SolResolver.resolveContractMembers$default(engine.kt:362)
	...
```