### PR TITLE
Feature/support foundry toml remapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ intellij {
     type = 'IU'
     downloadSources = true
     updateSinceUntilBuild = false
-    plugins = ['JavaScript']
+    plugins = ['JavaScript','org.toml.lang:231.8109.1']
 
     sandboxDir = project.rootDir.canonicalPath + "/.sandbox"
 }

--- a/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
@@ -120,7 +120,7 @@ class SolContextCompletionContributor : CompletionContributor(), DumbAware {
               else text.lastIndexOf("/").takeIf { it >= 0 }?.let { text.substring(0, it) } ?: text
               if (!dirText.endsWith("/")) dirText += "/"
               val curFile = parameters.originalFile.virtualFile
-              val vPath = SolImportPathReference.findImportFile(curFile, dirText)
+              val vPath = SolImportPathReference.findImportFile(curFile, dirText, parameters.position.project)
               val elements = (vPath?.children ?: emptyArray())
                 .filter { it.isDirectory || it.extension == SolidityFileType.defaultExtension }
                 .map { LookupElementBuilder.create("\"$dirText${it.name}").withIcon(SolidityIcons.FILE_ICON) } +

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -1,5 +1,6 @@
 package me.serce.solidity.lang.resolve.ref
 
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
@@ -7,7 +8,9 @@ import com.intellij.psi.impl.source.tree.LeafElement
 import me.serce.solidity.ide.inspections.fixes.ImportFileAction
 import me.serce.solidity.lang.core.SolidityFile
 import me.serce.solidity.lang.psi.impl.SolImportPathElement
-import java.nio.file.Paths;
+import org.toml.lang.psi.TomlArray
+import org.toml.lang.psi.TomlKeyValueOwner
+import java.nio.file.Paths
 
 class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<SolImportPathElement>(element) {
   override fun singleResolve(): PsiElement? {
@@ -16,13 +19,13 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
       return null
     }
     val path = importText.substring(1, importText.length - 1)
-    return findImportFile(element.containingFile.originalFile.virtualFile, path)
+    return findImportFile(element.containingFile.originalFile.virtualFile, path, element.project )
       ?.let { PsiManager.getInstance(element.project).findFile(it) }
   }
 
   companion object {
 
-    fun findImportFile(file: VirtualFile, path: String): VirtualFile? {
+    fun findImportFile(file: VirtualFile, path: String, project: Project): VirtualFile? {
       val directFile = file.findFileByRelativePath("../$path")
       return if (directFile != null) {
         directFile
@@ -35,7 +38,7 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
         if (ethPmFile != null) {
           return ethPmFile
         }
-        findFoundryImportFile(file, path)
+        findFoundryImportFile(file, path, project)
       }
     }
 
@@ -50,7 +53,7 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
 
     // apply foundry remappings to import path
     private fun applyRemappings(remappings: ArrayList<Pair<String, String>>, path: String): String {
-      var output = path;
+      var output = path
       remappings.forEach { (prefix, target) ->
         if (path.contains(prefix)) {
           output = path.replace(prefix, target)
@@ -61,20 +64,20 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
     }
 
     private fun foundryDefaultFallback(file: VirtualFile, path: String): VirtualFile? {
-      val count = Paths.get(path).nameCount;
+      val count = Paths.get(path).nameCount
       if (count < 2) {
         return null;
       }
-      val libName = Paths.get(path).subpath(0, 1).toString();
-      val libFile = Paths.get(path).subpath(1, count).toString();
-      val test = file.findFileByRelativePath("lib/$libName/src/$libFile");
+      val libName = Paths.get(path).subpath(0, 1).toString()
+      val libFile = Paths.get(path).subpath(1, count).toString()
+      val test = file.findFileByRelativePath("lib/$libName/src/$libFile")
       return test;
     }
 
     // default lib located at: forge-std/Test.sol => lib/forge-std/src/Test.sol
-    private fun findFoundryImportFile(file: VirtualFile, path: String): VirtualFile? {
-      val testRemappingFile = file.findFileByRelativePath("remappings.txt");
-      val remappings = arrayListOf<Pair<String, String>>();
+    private fun findFoundryImportFile(file: VirtualFile, path: String, project: Project): VirtualFile? {
+      val testRemappingFile = file.findFileByRelativePath("remappings.txt")
+      val remappings = arrayListOf<Pair<String, String>>()
       if (testRemappingFile != null) {
         val mappingsContents = testRemappingFile.contentsToByteArray().toString(Charsets.UTF_8).split("[\r\n]+".toRegex());
         mappingsContents.forEach { mapping ->
@@ -85,16 +88,37 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
         }
       }
 
-      val remappedPath = applyRemappings(remappings, path);
-      val testRemappedPath = file.findFileByRelativePath(remappedPath);
-      val testFoundryFallback = foundryDefaultFallback(file, path);
+      remappings += remappingsFromFoundryConfigFile(file, project)
+
+      val remappedPath = applyRemappings(remappings, path)
+      val testRemappedPath = file.findFileByRelativePath(remappedPath)
+      val testFoundryFallback = foundryDefaultFallback(file, path)
 
       return when {
         testRemappedPath != null -> testRemappedPath
         testFoundryFallback != null -> testFoundryFallback
-        file.parent != null -> findFoundryImportFile(file.parent, path)
+        file.parent != null -> findFoundryImportFile(file.parent, path, project)
         else -> null
       }
+    }
+
+    private fun remappingsFromFoundryConfigFile(file: VirtualFile, project: Project): List<Pair<String, String>> {
+      val foundryConfigFile = file.findFileByRelativePath("foundry.toml")
+      val remappings = arrayListOf<Pair<String, String>>()
+      if (foundryConfigFile != null) {
+        val foundryFile = PsiManager.getInstance(project).findFile(foundryConfigFile)
+        foundryFile?.children?.filterIsInstance<TomlKeyValueOwner>()?.flatMap { it.entries }
+          ?.find { it.key.segments.firstOrNull()?.name == "remappings" }
+          ?.let {
+            (it.value as TomlArray).elements.forEach { mapping ->
+              val splitMapping = mapping.text.trim('"').split("=")
+              if (splitMapping.size == 2) {
+                remappings.add(Pair(splitMapping[0].trim(), splitMapping[1].trim()))
+              }
+            }
+          }
+      }
+      return remappings
     }
 
     private fun findEthPMImportFile(file: VirtualFile, path: String): VirtualFile? {

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/SolImportPathReference.kt
@@ -60,18 +60,18 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
           return output
         }
       }
-      return output;
+      return output
     }
 
     private fun foundryDefaultFallback(file: VirtualFile, path: String): VirtualFile? {
       val count = Paths.get(path).nameCount
       if (count < 2) {
-        return null;
+        return null
       }
       val libName = Paths.get(path).subpath(0, 1).toString()
       val libFile = Paths.get(path).subpath(1, count).toString()
       val test = file.findFileByRelativePath("lib/$libName/src/$libFile")
-      return test;
+      return test
     }
 
     // default lib located at: forge-std/Test.sol => lib/forge-std/src/Test.sol
@@ -79,7 +79,7 @@ class SolImportPathReference(element: SolImportPathElement) : SolReferenceBase<S
       val testRemappingFile = file.findFileByRelativePath("remappings.txt")
       val remappings = arrayListOf<Pair<String, String>>()
       if (testRemappingFile != null) {
-        val mappingsContents = testRemappingFile.contentsToByteArray().toString(Charsets.UTF_8).split("[\r\n]+".toRegex());
+        val mappingsContents = testRemappingFile.contentsToByteArray().toString(Charsets.UTF_8).split("[\r\n]+".toRegex())
         mappingsContents.forEach { mapping ->
           val splitMapping = mapping.split("=")
           if (splitMapping.size == 2) {

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveFoundryTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveFoundryTest.kt
@@ -4,15 +4,29 @@ import me.serce.solidity.lang.psi.SolNamedElement
 
 class SolImportResolveFoundryTest : SolResolveTestBase() {
 
+  private val testcases = arrayListOf(
+    Pair("lib/forge-std/src/Test.sol","contracts/ImportUsageFoundryStd.sol"),
+    Pair("lib/solmate/src/tokens/ERC721.sol","contracts/ImportUsageFoundrySolmate.sol"),
+    Pair("lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol","contracts/ImportUsageFoundryOpenzeppelin.sol"),
+  );
+
   fun testImportPathResolveFoundryRemappings() {
-    val testcases = arrayListOf<Pair<String, String>>(
-      Pair("lib/forge-std/src/Test.sol","contracts/ImportUsageFoundryStd.sol"),
-      Pair("lib/solmate/src/tokens/ERC721.sol","contracts/ImportUsageFoundrySolmate.sol"),
-      Pair("lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol","contracts/ImportUsageFoundryOpenzeppelin.sol"),
-    );
     testcases.forEach { (targetFile, contractFile) ->
       val file1 = myFixture.configureByFile(targetFile)
       myFixture.configureByFile("remappings.txt")
+      myFixture.configureByFile(contractFile)
+      val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
+      val resolved = checkNotNull(refElement.reference?.resolve()) {
+        "Failed to resolve ${refElement.text}"
+      }
+      assertEquals(file1.name, resolved.containingFile.name)
+    }
+  }
+
+  fun testImportPathResolveFoundryFoundryFile() {
+    testcases.forEach { (targetFile, contractFile) ->
+      val file1 = myFixture.configureByFile(targetFile)
+      myFixture.configureByFile("foundry.toml")
       myFixture.configureByFile(contractFile)
       val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
       val resolved = checkNotNull(refElement.reference?.resolve()) {

--- a/src/test/resources/fixtures/importRemappings/foundry.toml
+++ b/src/test/resources/fixtures/importRemappings/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+
+remappings = [
+    "forge-std/=lib/forge-std/src/",
+    "@solmate/=lib/solmate/src/",
+    "@openzeppelin/=lib/openzeppelin-contracts/contracts/",
+]


### PR DESCRIPTION
With foundry and soldeer, it's possible to define remappings only in the foundry.toml
This PR will support the toml config file and resolve path reference