### PR TITLE
Feature/file level import

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -34,7 +34,8 @@ object SolResolver {
           resolveEnum(element) +
           resolveStruct(element) +
           resolveUserDefinedValueType(element) +
-          resolveAliases(element)
+          resolveAliases(element) +
+          resolveConstant(element)
       }
       CachedValueProvider.Result.create(result, PsiModificationTracker.MODIFICATION_COUNT)
     }
@@ -49,10 +50,7 @@ object SolResolver {
     file: PsiFile,
   ): Set<T> {
     // If the elements has no name or text, we can't resolve it.
-    val elementName = element.nameOrText
-    if (elementName == null) {
-      return emptySet()
-    }
+    val elementName = element.nameOrText ?: return emptySet()
 
 
     // Retrieve all PSI elements with the name we're trying to lookup.
@@ -198,6 +196,8 @@ object SolResolver {
       element,
       { it.userDefinedValueTypeDefinitionList }) + resolveUsingImports(SolUserDefinedValueTypeDefinition::class.java, element, element.containingFile)
 
+  private fun resolveConstant(element: PsiElement): Set<SolNamedElement> =
+    resolveUsingImports(SolConstantVariable::class.java, element, element.containingFile)
   private fun resolveEvent(element: PsiElement): Set<SolNamedElement> =
     resolveInnerType<SolEventDefinition>(element) { it.eventDefinitionList }
 

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -537,11 +537,14 @@ object SolResolver {
           val userDefinedTypes = scopeChildren.asSequence()
             .filterIsInstance<SolUserDefinedValueTypeDefinition>()
 
+          val enums = scopeChildren.asSequence()
+            .filterIsInstance<SolEnumDefinition>()
+
           val imports = scopeChildren.asSequence().filterIsInstance<SolImportDirective>()
             .mapNotNull {  it.importPath?.reference?.resolve()?.containingFile }
             .map { lexicalDeclarations(visitedScopes, it, place) }
             .flatten()
-          imports + contracts + constantVariables + freeFunctions + userDefinedTypes
+          imports + contracts + constantVariables + freeFunctions + userDefinedTypes + enums
         } ?: emptySequence()
       }
 

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -28,7 +28,8 @@ object SolResolver {
           resolveEvent(element) +
           resolveContract(element) +
           resolveEnum(element) +
-          resolveUserDefinedValueType(element)
+          resolveUserDefinedValueType(element) +
+          resolveConstant(element)
       } else {
         resolveContract(element) +
           resolveEnum(element) +

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -31,7 +31,8 @@ object SolResolver {
           resolveUserDefinedValueType(element) +
           resolveConstant(element)
       } else {
-        resolveContract(element) +
+        resolveError(element) +
+          resolveContract(element) +
           resolveEvent(element) +
           resolveEnum(element) +
           resolveStruct(element) +

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -32,6 +32,7 @@ object SolResolver {
           resolveConstant(element)
       } else {
         resolveContract(element) +
+          resolveEvent(element) +
           resolveEnum(element) +
           resolveStruct(element) +
           resolveUserDefinedValueType(element) +
@@ -200,7 +201,7 @@ object SolResolver {
   private fun resolveConstant(element: PsiElement): Set<SolNamedElement> =
     resolveUsingImports(SolConstantVariable::class.java, element, element.containingFile)
   private fun resolveEvent(element: PsiElement): Set<SolNamedElement> =
-    resolveInnerType<SolEventDefinition>(element) { it.eventDefinitionList }
+    resolveInnerType<SolEventDefinition>(element) { it.eventDefinitionList } + resolveUsingImports(SolEventDefinition::class.java, element, element.containingFile)
 
   private fun resolveError(element: PsiElement): Set<SolNamedElement> =
     resolveInnerType<SolErrorDefinition>(element) { it.errorDefinitionList } + resolveUsingImports(SolErrorDefinition::class.java, element, element.containingFile)

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
@@ -124,6 +124,9 @@ class SolFunctionCallReference(element: SolFunctionCallExpression) : SolReferenc
     if (element.parent is SolRevertStatement) {
       return SolResolver.resolveTypeNameUsingImports(element).filterIsInstance<SolErrorDefinition>()
     }
+    if (element.parent is SolEmitStatement) {
+      return SolResolver.resolveTypeNameUsingImports(element).filterIsInstance<SolEventDefinition>()
+    }
     if (element.firstChild is SolPrimaryExpression) {
       val structs = SolResolver.resolveTypeNameUsingImports(element.firstChild).filterIsInstance<SolStructDefinition>()
       if (structs.isNotEmpty()) {

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEnumResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEnumResolveTest.kt
@@ -13,8 +13,6 @@ class SolEnumResolveTest : SolResolveTestBase() {
         }
   """)
 
-  // TODO: implement top level enum resolution
-  /*
   fun testEnumResolveInFile() = checkByCode("""
       enum B { A1, A2 }
          //x
@@ -26,7 +24,6 @@ class SolEnumResolveTest : SolResolveTestBase() {
           }
       }
   """)
-  */
 
   fun testEnumItself() = checkByCode("""
         contract A {

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEnumResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEnumResolveTest.kt
@@ -101,4 +101,55 @@ class SolEnumResolveTest : SolResolveTestBase() {
             }
         }
   """)
+
+  fun testResolveImportedEnum() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+           enum B { A1, A2 }
+              //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {B} from "./a.sol";
+                //^
+          contract b {
+              function f() {
+                  B.A2;
+              }
+          }
+    """
+    )
+  )
+
+  fun testResolveImportedEnum2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+           enum B { A1, A2 }
+              //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {B} from "./a.sol";
+                
+          contract b {
+              function f() {
+                  B.A2;
+                //^
+              }
+          }
+    """
+    )
+  )
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolErrorResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolErrorResolveTest.kt
@@ -29,7 +29,7 @@ class SolErrorResolveTest : SolResolveTestBase() {
         }
   """)
 
-  fun testErrorWithParemeters() = checkByCode("""
+  fun testErrorWithParameters() = checkByCode("""
         contract B {
             error Refunded(int a, uint256 b);
                     //x

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolErrorResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolErrorResolveTest.kt
@@ -41,6 +41,74 @@ class SolErrorResolveTest : SolResolveTestBase() {
         }
   """)
 
+  fun testErrorAtFileLevel() = checkByCode(
+    """
+        pragma solidity ^0.8.26;
+        
+        error Refunded(int a, uint256 b);
+                //x
+        contract B {
+            function close() public {
+                revert Refunded(1, 2);
+                       //^
+            }
+        }
+  """
+  )
+
+  fun testResolveImportedError() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+          error Closed();
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Closed} from "./a.sol";
+                  //^
+          contract b {
+              function close() public {
+                revert Closed();
+              }
+          }
+                      
+    """
+    )
+  )
+
+  fun testResolveImportedError2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+          error Closed();
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Closed} from "./a.sol";
+                  
+          contract b {
+              function close() public {
+                revert Closed();
+                      //^
+              }
+          }
+                      
+    """
+    )
+  )
+
   override fun checkByCode(code: String) {
     checkByCodeInternal<SolFunctionCallExpression, SolNamedElement>(code)
   }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
@@ -77,6 +77,59 @@ class SolEventResolveTest : SolResolveTestBase() {
     )
   }
 
+  fun testResolveImportedEvent() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+          event Closed();
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Closed} from "./a.sol";
+                  //^
+          contract b {
+              function emitEvent() public {
+                emit Closed();
+              }
+          }
+                      
+    """
+    )
+  )
+
+  fun testResolveImportedEvent2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+          
+          event Closed();
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Closed} from "./a.sol";
+                  
+          contract b {
+              function emitEvent() public {
+                emit Closed();
+                      //^
+              }
+          }
+                      
+    """
+    )
+  )
+
 
   override fun checkByCode(code: String) {
     checkByCodeInternal<SolFunctionCallExpression, SolNamedElement>(code)

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
@@ -77,6 +77,22 @@ class SolEventResolveTest : SolResolveTestBase() {
     )
   }
 
+  fun testEventAtFileLevel() = checkByCode(
+    """
+        pragma solidity ^0.8.26;
+        
+        event Refunded(int a, uint256 b);
+                //x
+        contract B {
+
+            function close() public {
+                emit Refunded(1, 2);
+                    //^
+            }
+        }
+  """
+  )
+
   fun testResolveImportedEvent() = testResolveBetweenFiles(
     InlineFile(
       code = """

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
@@ -8,12 +8,14 @@ class SolEventResolveTest : SolResolveTestBase() {
 
   fun testEventWithNoArguments() = checkByCode(
     """
+       pragma solidity ^0.8.26;
+       
         contract B {
             event Closed();
                     //x
-            function close() {
-                Closed();
-                //^
+            function close() public {
+                emit Closed();
+                    //^
             }
         }
   """
@@ -21,29 +23,33 @@ class SolEventResolveTest : SolResolveTestBase() {
 
   fun testEventParent() = checkByCode(
     """
+       pragma solidity ^0.8.26;
+       
         contract A {
             event Closed();
                     //x
         }
 
         contract B is A {
-            function close() {
-                Closed();
-                //^
+            function close() public {
+                emit Closed();
+                    //^
             }
         }
   """
   )
 
-  fun testEventWithParemeters() = checkByCode(
+  fun testEventWithParameters() = checkByCode(
     """
+       pragma solidity ^0.8.26;
+       
         contract B {
             event Refunded(int a, uint256 b);
                     //x
 
-            function close() {
-                Refunded(1, 2);
-                //^
+            function close() public {
+                emit Refunded(1, 2);
+                      //^
             }
         }
   """
@@ -61,6 +67,8 @@ class SolEventResolveTest : SolResolveTestBase() {
     RecursionManager.disableMissedCacheAssertions(testRootDisposable)
     checkByCode(
       """
+         pragma solidity ^0.8.26;
+         
         contract B {
             event B();
                    
@@ -69,7 +77,7 @@ class SolEventResolveTest : SolResolveTestBase() {
                    //^
             }
             
-            function B() {
+            function B() public {
                    //x
             }
         }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolEventResolveTest.kt
@@ -71,6 +71,7 @@ class SolEventResolveTest : SolResolveTestBase() {
          
         contract B {
             event B();
+                //x  
                    
             function close() public {
                 emit B();
@@ -78,11 +79,38 @@ class SolEventResolveTest : SolResolveTestBase() {
             }
             
             function B() public {
-                   //x
             }
         }
     """
     )
+  }
+
+  fun testContractTheSameNameAsEvent2() {
+    // A recursion guard check is disabled to prevent c.i.o.u.RecursionManager.CachingPreventedException
+    // from being thrown. The case highlights another issue that's worth fixing.
+    RecursionManager.disableMissedCacheAssertions(testRootDisposable)
+    InlineFile(
+      """
+         pragma solidity ^0.8.26;
+         
+        contract B {
+            event B();
+                   
+            function close() public {
+                emit B();
+            }
+            
+            function B() public {
+                   //^
+            }
+        }
+    """
+    )
+
+    val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
+
+    val references = refElement.references.mapNotNull { it?.resolve() }
+    assertTrue("Should fail to resolve ${refElement.text}", references.isEmpty())
   }
 
   fun testEventAtFileLevel() = checkByCode(

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolStructResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolStructResolveTest.kt
@@ -79,18 +79,19 @@ class SolStructResolveTest : SolResolveTestBase() {
       }
   """)
 
-  fun testResolveImportedStruct() {
-    val file1 = InlineFile(
+  fun testResolveImportedStruct() = testResolveBetweenFiles(
+    InlineFile(
       code = """
         struct Proposal {
                 //x
             uint256 id;
         }
-      """.trimIndent(),
+      """,
       name = "Abc.sol"
-    )
+    ),
 
-    val file2 = InlineFile("""
+    InlineFile(
+      """
         import "./Abc.sol";
         contract B { 
             function doit(uint256[] storage array) {
@@ -98,8 +99,33 @@ class SolStructResolveTest : SolResolveTestBase() {
                                    //^
             }
         }
-    """)
+    """
+    )
 
-    testResolveBetweenFiles(file1, file2)
-  }
+  )
+
+  fun testResolveImportedStruct2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+        struct Proposal {
+                //x
+            uint256 id;
+        }
+      """,
+      name = "Abc.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;    
+            
+          import {Proposal} from "./Abc.sol";
+                    //^
+          contract B { 
+            function doit(uint256[] storage array) {
+                Proposal prop = Proposal(1);
+            }
+        }
+    """
+    )
+  )
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolUserDefinedValueTypeResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolUserDefinedValueTypeResolveTest.kt
@@ -20,4 +20,53 @@ class SolUserDefinedValueTypeResolveTest : SolResolveTestBase() {
                                             //^
         }
   """)
+
+  fun testUserDefinedValueTypeResolveImported() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+                
+          type Decimal18 is uint256;
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Decimal18} from "./a.sol";
+                  //^
+          contract b {
+            Decimal18 public user;
+          }
+                      
+    """
+    )
+  )
+
+  fun testUserDefinedValueTypeResolveImported2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+                
+          type Decimal18 is uint256;
+                  //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {Decimal18} from "./a.sol";
+                  
+          contract b {
+            Decimal18 public user;
+            //^
+          }
+                      
+    """
+    )
+  )
 }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolVarResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolVarResolveTest.kt
@@ -284,4 +284,61 @@ class SolVarResolveTest : SolResolveTestBase() {
         }          
     """)
 
+  fun testResolveImportedConstant() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+                
+          address constant USER_1 = address(0x1111111111111111111111111111111111111111);
+                          //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {USER_1} from "./a.sol";
+                  //^
+          contract b {
+            address public user;
+
+              function setUser() public {
+                user = USER_1;
+              }
+          }
+                      
+    """
+    )
+  )
+
+  fun testResolveImportedConstant2() = testResolveBetweenFiles(
+    InlineFile(
+      code = """
+          pragma solidity ^0.8.26;
+                
+          address constant USER_1 = address(0x1111111111111111111111111111111111111111);
+                          //x
+      """,
+      name = "a.sol"
+    ),
+    InlineFile(
+      """
+          pragma solidity ^0.8.26;      
+                
+          import {USER_1} from "./a.sol";
+                  
+          contract b {
+            address public user;
+
+              function setUser() public {
+                user = USER_1;
+                        //^
+              }
+          }
+                      
+    """
+    )
+  )
+
 }


### PR DESCRIPTION
At file level, outside a contract, it's possible to define a constant, an enum, a struct, a custom type or an error. 
Their resolution wasn't handled for some of them. This PR aim to fix this

It's also seem to fix #309 see 