### PR TITLE
fix: import resolution libraries with same name

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -217,6 +217,7 @@ object SolResolver {
 
   private fun isExternalLibrary(element: SolContractDefinition): Boolean {
     return (element.contractType == ContractType.LIBRARY
+      && element.functionDefinitionList.isNotEmpty()
       && element.functionDefinitionList.all { function ->
         function.visibility == Visibility.EXTERNAL
           || function.visibility == Visibility.PUBLIC

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -198,7 +198,9 @@ object SolResolver {
               }
             }
           } else containingFile.childrenOfType<SolCallableElement>().toList()
-            .flatMap { element -> (if (element is SolContractDefinition) resolveContractMembers(element) else emptyList()) + element }
+            .flatMap { element ->
+              (if (element is SolContractDefinition) resolveContractMembers(element) else emptyList()) + element
+            } + containingFile.childrenOfType<SolUserDefinedValueTypeDefElement>()
           ImportRecord(containingFile, names.filterIsInstance<SolNamedElement>())
         }
       }

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -198,7 +198,7 @@ object SolResolver {
               }
             }
           } else containingFile.childrenOfType<SolCallableElement>().toList()
-            .flatMap { element -> (if (element is SolContractDefinition) resolveContractMembers(element) else emptyList()) + it }
+            .flatMap { element -> (if (element is SolContractDefinition) resolveContractMembers(element) else emptyList()) + element }
           ImportRecord(containingFile, names.filterIsInstance<SolNamedElement>())
         }
       }

--- a/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/core/resolve/SolImportResolveTest.kt
@@ -50,6 +50,21 @@ class SolImportResolveTest : SolResolveTestBase() {
     assertEquals("abc", resolved.name)
   }
 
+  fun testResolveFunctionImportClash() {
+    myFixture.configureByFile("contracts/a/lib.sol")
+    myFixture.configureByFile("contracts/b/b.sol")
+    myFixture.configureByFile("contracts/b/lib.sol")
+
+    myFixture.configureByFile("contracts/ImportLibNameClash.sol")
+    val (refElement) = findElementAndDataInEditor<SolNamedElement>("^")
+
+    val resolved = checkNotNull(refElement.reference?.resolve() as? PsiNamedElement) {
+      "Failed to resolve ${refElement.text}"
+    }
+
+    assertEquals("lib", resolved.name)
+  }
+
   fun testRecursiveImport() {
     myFixture.configureByFile("recursive/B.sol")
     myFixture.configureByFile("recursive/C.sol")

--- a/src/test/resources/fixtures/import/contracts/ImportLibNameClash.sol
+++ b/src/test/resources/fixtures/import/contracts/ImportLibNameClash.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {lib} from "./a/lib.sol";
+      //^
+import { b } from "./b/b.sol";
+
+library ImportLibNameClash {
+    function test() external returns(uint256){
+        return lib.functionA() + b.functionB();
+    }
+}

--- a/src/test/resources/fixtures/import/contracts/a/lib.sol
+++ b/src/test/resources/fixtures/import/contracts/a/lib.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.26;
 
 library lib {
-      //x
     function functionA() internal returns(uint256) {
         return 10;
     }

--- a/src/test/resources/fixtures/import/contracts/a/lib.sol
+++ b/src/test/resources/fixtures/import/contracts/a/lib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.26;
 
 library lib {
-      //^
+      //x
     function functionA() internal returns(uint256) {
         return 10;
     }

--- a/src/test/resources/fixtures/import/contracts/a/lib.sol
+++ b/src/test/resources/fixtures/import/contracts/a/lib.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+library lib {
+      //^
+    function functionA() internal returns(uint256) {
+        return 10;
+    }
+}

--- a/src/test/resources/fixtures/import/contracts/b/b.sol
+++ b/src/test/resources/fixtures/import/contracts/b/b.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {lib} from "./lib.sol";
+
+library b{
+    function functionB() external returns(uint256) {
+        return 10 + lib.functionLib();
+    }
+}

--- a/src/test/resources/fixtures/import/contracts/b/lib.sol
+++ b/src/test/resources/fixtures/import/contracts/b/lib.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+library lib{
+    function functionLib() internal returns(uint256) {
+        return 20;
+    }
+}


### PR DESCRIPTION
Fix an edge case where 2 libraries can have the same name if one of them is used as external libraries.
It was not possible for the solver to know which one of them was the right one.
The function collectImports now doesn't collect imports if it's from an external library