### PR TITLE
fix 441: add enums to the structure view

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/structure.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/structure.kt
@@ -139,12 +139,13 @@ private fun compare(o1: Any?, o2: Any?, getter: (SolFunctionDefinition) -> Enum<
 }
 
 class SolTreeElement(item: PsiFile) : PsiTreeElementBase<PsiFile>(item) {
-  override fun getPresentableText() = element?.virtualFile?.presentableName // TODO: name
+  override fun getPresentableText() = element?.name
 
   override fun getChildrenBase(): Collection<StructureViewTreeElement> {
     val el = element ?: return emptyList()
     return (el.childrenOfType<SolContractDefinition>().map(::SolContractTreeElement) +
-      el.childrenOfType<SolStructDefinition>().map(::SolStructTreeElement))
+      el.childrenOfType<SolStructDefinition>().map(::SolStructTreeElement) +
+      el.childrenOfType<SolEnumDefinition>().map(::SolLeafTreeElement))
       .sortedBy { it.element?.textOffset }
   }
 }

--- a/src/test/kotlin/me/serce/solidity/ide/structure/SolStructureViewTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/structure/SolStructureViewTest.kt
@@ -1,0 +1,23 @@
+package me.serce.solidity.ide.structure
+
+import me.serce.solidity.ide.SolStructureViewModel
+import me.serce.solidity.lang.core.SolidityFile
+import me.serce.solidity.lang.psi.SolNamedElement
+import me.serce.solidity.utils.SolTestBase
+
+class SolStructureViewTest : SolTestBase() {
+  fun testFileLevelEnumIsVisible() {
+    val file = InlineFile(
+      """
+        enum TestEnum {A, B}
+        contract C {}
+      """.trimIndent()
+    )
+    val model = SolStructureViewModel(myFixture.editor, file.psiFile as SolidityFile)
+    val root = model.root
+    val names = root.children.mapNotNull { it?.value }
+      .filterIsInstance<SolNamedElement>()
+      .map { it.name }
+    assertEquals(listOf("TestEnum", "C"), names)
+  }
+}


### PR DESCRIPTION
This PR fixes https://github.com/intellij-solidity/intellij-solidity/issues/441, the bug likely appeared when the enums were allowed on the top level in Solidity.