### PR TITLE
Fix deprecated endOffset usage

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/annotation/annotator.kt
@@ -5,7 +5,7 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.refactoring.suggested.endOffset
+import me.serce.solidity.ide.hints.endOffset
 import me.serce.solidity.ide.colors.SolColor
 import me.serce.solidity.ide.hints.startOffset
 import me.serce.solidity.lang.psi.*

--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolImportOptimizer.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolImportOptimizer.kt
@@ -54,8 +54,8 @@ class SolImportOptimizer : ImportOptimizer {
     val first = list.first().containingFile.let { it.children.filterIsInstance<SolPragmaDirective>().firstOrNull() ?: it.firstChild }
     val parent = first.parent
     list.forEach { it.delete() }
-    imports.reversed().forEach { parent.addAfter(it, first) }
-    parent.childrenOfType<SolImportDirective>().reversed().filter { SolResolver.collectUsedElements(it).isEmpty() }.forEach { it.delete() }
+    imports.asReversed().forEach { parent.addAfter(it, first) }
+    parent.childrenOfType<SolImportDirective>().asReversed().filter { SolResolver.collectUsedElements(it).isEmpty() }.forEach { it.delete() }
   }
 
   private fun processLight(file: PsiFile, list: List<SolImportDirective>): Runnable {

--- a/src/main/kotlin/me/serce/solidity/ide/hints/AbstractParameterInfoHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/hints/AbstractParameterInfoHandler.kt
@@ -29,3 +29,6 @@ abstract class AbstractParameterInfoHandler<O : PsiElement, T : Any> : Parameter
 
 val PsiElement.startOffset: Int
   get() = textRange.startOffset
+
+val PsiElement.endOffset: Int
+  get() = textRange.endOffset

--- a/src/main/kotlin/me/serce/solidity/ide/hints/SolDocumentationProvider.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/hints/SolDocumentationProvider.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.*
 import com.intellij.psi.util.elementType
-import com.intellij.refactoring.suggested.endOffset
+import me.serce.solidity.ide.hints.endOffset
 import com.jetbrains.rd.util.getOrCreate
 import me.serce.solidity.ide.SolHighlighter
 import me.serce.solidity.ide.colors.SolColor
@@ -97,7 +97,7 @@ class SolDocumentationProvider : AbstractDocumentationProvider() {
           else -> emptyList()
         }
       } else emptyList()
-    }.reversed()
+      }.asReversed()
     if (comments.isNotEmpty()) {
       builder.append(CONTENT_START)
       var prevText = ""

--- a/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/contributors.kt
@@ -12,7 +12,7 @@ import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.impl.source.tree.LeafPsiElement
-import com.intellij.refactoring.suggested.endOffset
+import me.serce.solidity.ide.hints.endOffset
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.util.ProcessingContext

--- a/src/main/kotlin/me/serce/solidity/lang/psi/impl/impl.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/impl/impl.kt
@@ -44,8 +44,8 @@ abstract class SolStubbedElementImpl<StubT : StubElement<*>> : StubBasedPsiEleme
 
   override fun getReference(): SolReference? = null
 
-  // FQN isn't needed in paring tests
-  override fun toString(): String = "${javaClass.simpleName}($elementType)"
+  // FQN isn't needed in parsing tests
+  override fun toString(): String = "${javaClass.simpleName}(${node.elementType})"
 }
 
 abstract class SolStubbedNamedElementImpl<S> :

--- a/src/main/kotlin/me/serce/solidity/lang/types/types.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/types.kt
@@ -225,7 +225,7 @@ data class SolContract(val ref: SolContractDefinition, val builtin: Boolean = fa
       .flatMap { it.reference?.multiResolve() ?: emptyList() }
       .filterIsInstance<SolContractDefinition>()
       .map { SolContract(it) }
-      .reversed()
+      .asReversed()
   }
 
   override fun isAssignableFrom(other: SolType): Boolean =


### PR DESCRIPTION
## Summary
- implement our own `PsiElement.endOffset`
- update `SolDocumentationProvider`, `SolitidyAnnotator`, and completions to use the new property
- avoid deprecated `StubBasedPsiElementBase.getElementType` in `toString`
- use `asReversed` to avoid missing List.reversed during tests

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6851f51f36a083299c839053aad4baf9