### PR TITLE
fix #201: support renaming of qualified refs

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/psi/impl/mixins.kt
@@ -464,6 +464,18 @@ abstract class SolUserDefinedTypeNameImplMixin : SolStubbedElementImpl<SolTypeRe
 
   override fun getReference(): SolReference = SolUserDefinedTypeNameReference(this)
 
+  override fun getReferences(): Array<SolReference> {
+    val identifiers = findIdentifiers()
+    val baseRef = SolUserDefinedTypeNameReference(this)
+    return when {
+      identifiers.size > 1 -> arrayOf(
+        SolQualifierTypeNameReference(this, identifiers.first()), baseRef
+      )
+
+      else -> arrayOf(baseRef)
+    }
+  }
+
   override val referenceNameElement: PsiElement
     get() = findIdentifiers().last()
 

--- a/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/ref/refs.kt
@@ -27,6 +27,24 @@ class SolUserDefinedTypeNameReference(element: SolUserDefinedTypeName) : SolRefe
   override fun getVariants() = SolCompleter.completeTypeName(element)
 }
 
+class SolQualifierTypeNameReference(
+  element: SolUserDefinedTypeName, private val identifier: PsiElement
+) : SolReferenceBase<SolUserDefinedTypeName>(element), SolReference {
+
+  override fun calculateDefaultRangeInElement(): TextRange {
+    return TextRange(identifier.startOffsetInParent, identifier.startOffsetInParent + identifier.textLength)
+  }
+
+  override fun multiResolve(): Collection<PsiElement> {
+    return SolResolver.resolveTypeNameUsingImports(identifier)
+  }
+
+  override fun handleElementRename(newName: String): PsiElement {
+    doRename(identifier, newName)
+    return element
+  }
+}
+
 class SolVarLiteralReference(element: SolVarLiteral) : SolReferenceBase<SolVarLiteral>(element), SolReference {
   override fun multiResolve() = SolResolver.resolveVarLiteralReference(element)
 

--- a/src/test/kotlin/me/serce/solidity/ide/refactoring/renameTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/refactoring/renameTest.kt
@@ -151,6 +151,47 @@ class RenameTest : SolTestBase() {
         }
     """)
 
+  fun testStructInALibraryScopeRename() = doTest(
+    "cat", """
+        library lib {
+            struct dog/*caret*/ {
+                uint256 a;
+                uint256 b;
+            }
+
+            function f() internal returns (dog memory) {
+                dog memory r;
+                return r;
+            }
+        }
+
+        contract c {
+            function f() internal returns (lib.dog memory) {
+                return lib.f();
+            }
+        }
+    """, """
+        library lib {
+            struct cat {
+                uint256 a;
+                uint256 b;
+            }
+
+            function f() internal returns (cat memory) {
+                cat memory r;
+                return r;
+            }
+        }
+
+        contract c {
+            function f() internal returns (lib.cat memory) {
+                return lib.f();
+            }
+        }
+    """
+  )
+
+
   private fun doTest(
     newName: String,
     @Language("Solidity") before: String,

--- a/src/test/kotlin/me/serce/solidity/ide/refactoring/renameTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/refactoring/renameTest.kt
@@ -113,6 +113,44 @@ class RenameTest : SolTestBase() {
     myFixture.checkResultByFile("imports/nested/ImportingFile_after.sol")
   }
 
+  fun testLibraryRename() = doTest("lib2", """
+        library /*caret*/lib {
+            struct dog {
+                uint256 a;
+                uint256 b;
+            }
+
+            function f() internal returns (dog memory) {
+                dog memory r;
+                return r;
+            }
+        }
+
+        contract c {
+            function f() internal returns (lib.dog memory) {
+                return lib.f();
+            }
+        }
+    """, """
+        library lib2 {
+            struct dog {
+                uint256 a;
+                uint256 b;
+            }
+
+            function f() internal returns (dog memory) {
+                dog memory r;
+                return r;
+            }
+        }
+
+        contract c {
+            function f() internal returns (lib2.dog memory) {
+                return lib2.f();
+            }
+        }
+    """)
+
   private fun doTest(
     newName: String,
     @Language("Solidity") before: String,


### PR DESCRIPTION
This PR introduces `SolQualifierTypeNameReference` to support renaming of the qualified references. 