### PR TITLE
fix an exception on lookup paint

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/completion/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/engine.kt
@@ -124,12 +124,16 @@ object SolCompleter {
 
 }
 
-class ContractLookupElement(val contract: SolContractDefinition) : LookupElement() {
-  override fun getLookupString(): String = contract.name!!
+class ContractLookupElement(private val contract: SolContractDefinition) : LookupElement() {
+  // read the lookup string on the contract lookup element construction to avoid the exception
+  // when #getLookupString is called without a read action when the UI is painted.
+  private val contractName: String = contract.name ?: ""
+
+  override fun getLookupString(): String = contractName
 
   override fun renderElement(presentation: LookupElementPresentation) {
     presentation.icon = contract.icon
-    presentation.itemText = contract.name
+    presentation.itemText = contractName
     presentation.typeText = "from ${contract.containingFile.name}"
   }
 

--- a/src/test/kotlin/me/serce/solidity/lang/completion/ContractLookupElementTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/completion/ContractLookupElementTest.kt
@@ -1,0 +1,19 @@
+package me.serce.solidity.lang.completion
+
+import com.intellij.openapi.application.ApplicationManager
+import me.serce.solidity.lang.psi.SolContractDefinition
+import me.serce.solidity.lang.psi.childOfType
+import java.util.concurrent.TimeUnit
+
+class ContractLookupElementTest : SolCompletionTestBase() {
+  fun testContractLookupStringAvailableOutsideReadAction() {
+    val file = InlineFile("contract Foo {}").psiFile
+    val contract = file.childOfType<SolContractDefinition>()!!
+    val lookup = ContractLookupElement(contract)
+
+    val future = ApplicationManager.getApplication().executeOnPooledThread<String> {
+      lookup.lookupString
+    }
+    assertEquals("Foo", future.get(5, TimeUnit.SECONDS))
+  }
+}


### PR DESCRIPTION
This change is meant to fix the following exception:
```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action only (see Application.runReadAction()); If you access or modify model on EDT consider wrapping your code in WriteIntentReadAction ; see https://jb.gg/ij-platform-threading for details
Current thread: Thread[#60,AWT-EventQueue-0,6,main] 881815464 (EventQueue.isDispatchThread()=true)
SystemEventQueueThread: (same)
    at com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:257)
    at com.intellij.util.concurrency.ThreadingAssertions.softAssertReadAccess(ThreadingAssertions.java:173)
    at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1014)
    at com.intellij.psi.impl.source.PsiFileImpl.assertReadAccessAllowed(PsiFileImpl.java:194)
    at com.intellij.psi.impl.source.PsiFileImpl.getStubTreeOrFileElement(PsiFileImpl.java:722)
    at com.intellij.psi.impl.source.PsiFileImpl.getStubTree(PsiFileImpl.java:717)
    at com.intellij.psi.impl.source.SpineRef.getStub(SpineRef.java:27)
    at com.intellij.extapi.psi.StubBasedPsiElementBase.getStub(StubBasedPsiElementBase.java:358)
    at me.serce.solidity.lang.psi.impl.SolStubbedNamedElementImpl.getName(impl.kt:62)
    at me.serce.solidity.lang.completion.ContractLookupElement.getLookupString(engine.kt:128)
    at com.intellij.codeInsight.lookup.LookupElementDecorator.getLookupString(LookupElementDecorator.java:42)
...
com.intellij.codeInsight.lookup.impl.LookupCellRenderer.getListCellRendererComponent(LookupCellRenderer.kt:59)
    at com.intellij.ui.ExpandedItemListCellRendererWrapper.getListCellRendererComponent(ExpandedItemListCellRendererWrapper.java:24)
    at com.intellij.ui.components.WideSelectionListUI.paintCell(WideSelectionListUI.java:57)
    at javax.swing.plaf.basic.BasicListUI.paintImpl(BasicListUI.java:383)
    at javax.swing.plaf.basic.BasicListUI.paint(BasicListUI.java:306)
    at com.intellij.ui.components.WideSelectionListUI.paint(WideSelectionListUI.java:35)
    at javax.swing.plaf.ComponentUI.update(ComponentUI.java:161)
    at javax.swing.JComponent.paintComponent(JComponent.java:855)
...
```