### PR TITLE
fix #494: do not add '*' after the comment ends

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/typing/SolBlockCommentEnterHandler.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/typing/SolBlockCommentEnterHandler.kt
@@ -24,6 +24,10 @@ class SolBlockCommentEnterHandler : EnterHandlerDelegateAdapter() {
     val indent = document.charsSequence.subSequence(lineStart, offset).toString()
 
     return when {
+      trimmedPrev.endsWith("*/") -> {
+        Result.Continue
+      }
+
       trimmedPrev.startsWith("/*") -> {
         document.insertString(offset, " * \n$indent */")
         editor.caretModel.moveToOffset(offset + 3)

--- a/src/test/kotlin/me/serce/solidity/ide/typing/SolBlockCommentEnterHandlerTest.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/typing/SolBlockCommentEnterHandlerTest.kt
@@ -14,6 +14,34 @@ class SolBlockCommentEnterHandlerTest : SolTestBase() {
     myFixture.type('\n')
   }
 
+  fun testBlockCommentAfterTheCommentEnds() = checkByText(
+    """
+      /*
+       * a comment
+       */<caret>
+    """.trimIndent(),
+    """
+      /*
+       * a comment
+       */
+      <caret>
+    """.trimIndent()
+  ) {
+    myFixture.type('\n')
+  }
+
+  fun testBlockCommentDoesNotIndentOneLineComments() = checkByText(
+    """
+      /* a comment */<caret>
+    """.trimIndent(),
+    """
+      /* a comment */
+      <caret>
+    """.trimIndent()
+  ) {
+    myFixture.type('\n')
+  }
+
   fun testBlockCommentContinuationWithDoubleStars() = checkByText(
     "/**<caret>",
     """


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/intellij-solidity/intellij-solidity/pull/495