### PR TITLE
update baseline intellij to 242.26775.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gen
 .sandbox
 .DS_Store
 /out/
+.intellijPlatform/
 
 ### Java ###
 *.class

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 version=2.4.8-SNAPSHOT
 group=me.serce
-kotlin_version=1.8.10
+kotlin_version=1.9.25
 sentry_version=1.6.4

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,10 +59,10 @@
 
     <!--
         See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-        See https://youtrack.jetbrains.com/articles/IDEA-A-2100661478/IntelliJ-IDEA-2023.1-231.8109.175-build-Release-Notes
-        231.8109.175 is IntelliJ IDEA 2023.1
+        See https://youtrack.jetbrains.com/articles/IDEA-A-2100662423/IntelliJ-IDEA-2024.2.6-242.26775.15-build-Release-Notes
+        242.26775.15 is IntelliJ IDEA 2024.2.6
     -->
-    <idea-version since-build="231.8109.175"/>
+    <idea-version since-build="242.26775.15"/>
 
     <!-- See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html for the full list of modules -->
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
This PR sets IntelliJ IDEA 2024.2.6 (242.26775.15) as the baseline for the next versions of the plugin. To make the change work, the PR also upgrades all relevant dependencies. 