### PR TITLE
openapi: migrate context type API

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/liveTemplates/SolTemplateContextType.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/liveTemplates/SolTemplateContextType.kt
@@ -6,7 +6,6 @@ import me.serce.solidity.lang.SolidityLanguage
 import java.util.*
 
 class SolTemplateContextType : FileTypeBasedContextType(
-  SolidityLanguage.id.uppercase(Locale.getDefault()),
   SolidityLanguage.id,
   SolidityFileType
 )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -254,6 +254,7 @@
 
         <defaultLiveTemplates file="/liveTemplates/Solidity.xml"/>
         <liveTemplateContext
+                contextId="SOLIDITY"
                 implementation="me.serce.solidity.ide.liveTemplates.SolTemplateContextType"/>
 
         <lang.structureViewExtension implementation="me.serce.solidity.ide.SolStructureViewExtension"/>


### PR DESCRIPTION
This PR resolves the `FileTypeBasedContextType` compatibility issue: 
<img width="975" height="110" alt="Screenshot 2025-08-16 at 11 15 17 am" src="https://github.com/user-attachments/assets/57ae87ea-1b57-4576-97b9-4033f81c35e5" />
