### PR TITLE
formatting: fix formatting of top level declarations

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolFormattingBlock.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolFormattingBlock.kt
@@ -75,7 +75,7 @@ open class SolFormattingBlock(
         STRUCT_DEFINITION
       ) -> Indent.getNormalIndent()
 
-      childType.isContractPart() -> Indent.getNormalIndent()
+      type == CONTRACT_DEFINITION && childType.isContractPart() -> Indent.getNormalIndent()
 
       // fields inside structs
       type == STRUCT_DEFINITION && childType == VARIABLE_DECLARATION -> Indent.getNormalIndent()

--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolidityFormattingModelBuilder.kt
@@ -12,8 +12,8 @@ import me.serce.solidity.lang.core.SolidityParserDefinition.Companion.CONTROL_ST
 import me.serce.solidity.lang.core.SolidityTokenTypes.*
 
 /**
- * Ideally we should fully implement this
- * https://github.com/ethereum/solidity/blob/develop/docs/style-guide.rst
+ * The formatter attempts to follow the official style guide while remaining configurable.
+ * https://docs.soliditylang.org/en/latest/style-guide.html
  */
 class SolidityFormattingModelBuilder : FormattingModelBuilder {
   override fun createModel(context: FormattingContext): FormattingModel {
@@ -31,78 +31,105 @@ class SolidityFormattingModelBuilder : FormattingModelBuilder {
     return null
   }
 
-  companion object {
-    fun createSpacingBuilder(settings: CodeStyleSettings): SpacingBuilder {
-      return SpacingBuilder(settings, SolidityLanguage)
-        .between(TokenSet.create(LPAREN, LBRACE, LBRACKET), COMMENT).spaces(1)
-        .after(TokenSet.create(LPAREN, LBRACE, LBRACKET)).none()
-        // Some old versions do not support .before(TokenSet), so we use more verbose form
-        // https://github.com/JetBrains/intellij-community/commit/fd4c8224c17d041bf53d556f5c74ffaf20acffe3
-        // no spaces between - and > to prevent the formatter from breaking -> which could be separate tokens.
-        .between(MINUS, MORE).none()
-        .before(RPAREN).none()
-        .before(RBRACE).none()
-        .before(RBRACKET).none()
-        .before(COMMA).none()
-        .before(SEMICOLON).none()
-        .around(BINARY_OPERATORS).spaces(1)
-        .beforeInside(COLON, MAP_EXPRESSION_CLAUSE).spaces(0)
-        .afterInside(COLON, MAP_EXPRESSION_CLAUSE).spaces(1)
-        .around(TokenSet.create(QUESTION, COLON, IS)).spaces(1)
-        .after(TokenSet.create(RETURNS, RETURN, IMPORT)).spaces(1)
-        .after(MAPPING).spaces(0)
-        .afterInside(TokenSet.create(NOT, TILDE, INC, DEC, PLUS, MINUS), UNARY_EXPRESSION).none()
-        .afterInside(DELETE, UNARY_EXPRESSION).spaces(1)
-        .afterInside(SEMICOLON, FOR_STATEMENT).spaces(1)
-        .beforeInside(SEMICOLON, FOR_STATEMENT).none()
-        .beforeInside(PARAMETER_LIST, FUNCTION_DEFINITION).none()
-        .beforeInside(IDENTIFIER, FUNCTION_DEFINITION).spaces(1)
-        .around(FUNCTION_INVOCATION).spaces(0)
-        .aroundInside(MODIFIER_INVOCATION, FUNCTION_DEFINITION).spaces(1)
-        .around(FUNCTION_VISIBILITY_SPECIFIER).spaces(1)
-        .around(STATE_MUTABILITY_SPECIFIER).spaces(1)
-        .betweenInside(MODIFIER_INVOCATION, MODIFIER_INVOCATION, FUNCTION_DEFINITION).spaces(1)
-        .aroundInside(TO, MAPPING_TYPE_NAME).spaces(1)
-        .aroundInside(TokenSet.create(
-          FUNCTION_CALL_EXPRESSION, CONSTANT, EXTERNAL, PUBLIC, INTERNAL, PRIVATE, IDENTIFIER),
-          FUNCTION_DEFINITION).spaces(1)
-        .beforeInside(LPAREN, FUNCTION_CALL_EXPRESSION).none()
-        .after(CONTROL_STRUCTURES).spaces(1)
-        .beforeInside(STATEMENT, TokenSet.create(IF_STATEMENT, WHILE_STATEMENT, FOR_STATEMENT, DO_WHILE_STATEMENT)).spaces(1)
-        .after(CONTRACT).spaces(1)
-        .aroundInside(IDENTIFIER, TokenSet.create(CONTRACT_DEFINITION, PRAGMA_DIRECTIVE, STRUCT_DEFINITION, PARAMETER_DEF)).spaces(1)
-        .afterInside(TYPE_NAME, TokenSet.create(VARIABLE_DECLARATION, PARAMETER_LIST, INDEXED_PARAMETER_LIST)).spaces(1)
-        .beforeInside(IDENTIFIER, TokenSet.create(VARIABLE_DECLARATION, PARAMETER_LIST, INDEXED_PARAMETER_LIST)).spaces(1)
-        .after(COMMA).spaces(1)
-        .beforeInside(BLOCK, STATEMENT).spaces(1)
-        .beforeInside(UNCHECKED_BLOCK, STATEMENT).spaces(1)
-        .beforeInside(LBRACE, CONTRACT_DEFINITION).spaces(1)
-        // else on the same line as }
-        .betweenInside(STATEMENT, ELSE, IF_STATEMENT).spaces(1)
-        .between(STATEMENT, COMMENT).spacing(0, Int.MAX_VALUE, 0, true, 1)
-        .after(STATEMENT).lineBreakInCode()
-        .between(LBRACE, RBRACE).none()
-        .afterInside(EXPRESSION, MEMBER_ACCESS_EXPRESSION).none()
-        .beforeInside(IDENTIFIER, MEMBER_ACCESS_EXPRESSION).none()
-        .between(IMPORT_DIRECTIVE, IMPORT_DIRECTIVE).blankLines(0)
-        // 0 lines between event definitions
-        .between(EVENT_DEFINITION, EVENT_DEFINITION).blankLines(0)
-        // 0 lines between error definitions
-        .between(ERROR_DEFINITION, ERROR_DEFINITION).blankLines(0)
-        // 1 line between pragma and import/contract definition
-        .between(PRAGMA_DIRECTIVE, TokenSet.create(IMPORT_DIRECTIVE, CONTRACT_DEFINITION)).blankLines(1)
-        // 1 line between pragma/import and contract definition
-        .between(TokenSet.create(PRAGMA_DIRECTIVE, IMPORT_DIRECTIVE), CONTRACT_DEFINITION).blankLines(1)
-        // 1 line between contracts
-        .between(CONTRACT_DEFINITION, CONTRACT_DEFINITION).blankLines(1)
-        // allow for 0 lines between state variable declarations
-        .between(STATE_VARIABLE_DECLARATION, STATE_VARIABLE_DECLARATION).blankLines(0)
-        // allow for 0 lines between state constant variable declarations
-        .between(CONSTANT_VARIABLE_DECLARATION, CONSTANT_VARIABLE_DECLARATION).blankLines(0)
-        .between(
-          TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, ERROR_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION),
-          TokenSet.create(FUNCTION_DEFINITION, EVENT_DEFINITION, ERROR_DEFINITION, STRUCT_DEFINITION, STATE_VARIABLE_DECLARATION)
-        ).blankLines(1)
-    }
+  private val topLevelDeclarations =
+    TokenSet.create(CONTRACT_DEFINITION, STRUCT_DEFINITION, ENUM_DEFINITION, ERROR_DEFINITION)
+
+  fun createSpacingBuilder(settings: CodeStyleSettings): SpacingBuilder {
+    return SpacingBuilder(settings, SolidityLanguage)
+      .between(TokenSet.create(LPAREN, LBRACE, LBRACKET), COMMENT).spaces(1)
+      .after(TokenSet.create(LPAREN, LBRACE, LBRACKET)).none()
+      // Some old versions do not support .before(TokenSet), so we use more verbose form
+      // https://github.com/JetBrains/intellij-community/commit/fd4c8224c17d041bf53d556f5c74ffaf20acffe3
+      // no spaces between - and > to prevent the formatter from breaking -> which could be separate tokens.
+      .between(MINUS, MORE).none()
+      .before(RPAREN).none()
+      .before(RBRACE).none()
+      .before(RBRACKET).none()
+      .before(COMMA).none()
+      .before(SEMICOLON).none()
+      .around(BINARY_OPERATORS).spaces(1)
+      .beforeInside(COLON, MAP_EXPRESSION_CLAUSE).spaces(0)
+      .afterInside(COLON, MAP_EXPRESSION_CLAUSE).spaces(1)
+      .around(TokenSet.create(QUESTION, COLON, IS)).spaces(1)
+      .after(TokenSet.create(RETURNS, RETURN, IMPORT)).spaces(1)
+      .after(MAPPING).spaces(0)
+      .afterInside(TokenSet.create(NOT, TILDE, INC, DEC, PLUS, MINUS), UNARY_EXPRESSION).none()
+      .afterInside(DELETE, UNARY_EXPRESSION).spaces(1)
+      .afterInside(SEMICOLON, FOR_STATEMENT).spaces(1)
+      .beforeInside(SEMICOLON, FOR_STATEMENT).none()
+      .beforeInside(PARAMETER_LIST, FUNCTION_DEFINITION).none()
+      .beforeInside(IDENTIFIER, FUNCTION_DEFINITION).spaces(1)
+      .around(FUNCTION_INVOCATION).spaces(0)
+      .aroundInside(MODIFIER_INVOCATION, FUNCTION_DEFINITION).spaces(1)
+      .around(FUNCTION_VISIBILITY_SPECIFIER).spaces(1)
+      .around(STATE_MUTABILITY_SPECIFIER).spaces(1)
+      .betweenInside(MODIFIER_INVOCATION, MODIFIER_INVOCATION, FUNCTION_DEFINITION).spaces(1)
+      .aroundInside(TO, MAPPING_TYPE_NAME).spaces(1)
+      .aroundInside(
+        TokenSet.create(
+          FUNCTION_CALL_EXPRESSION, CONSTANT, EXTERNAL, PUBLIC, INTERNAL, PRIVATE, IDENTIFIER
+        ),
+        FUNCTION_DEFINITION
+      ).spaces(1)
+      .beforeInside(LPAREN, FUNCTION_CALL_EXPRESSION).none()
+      .after(CONTROL_STRUCTURES).spaces(1)
+      .beforeInside(STATEMENT, TokenSet.create(IF_STATEMENT, WHILE_STATEMENT, FOR_STATEMENT, DO_WHILE_STATEMENT))
+      .spaces(1)
+      .after(CONTRACT).spaces(1)
+      .aroundInside(
+        IDENTIFIER,
+        TokenSet.create(CONTRACT_DEFINITION, PRAGMA_DIRECTIVE, STRUCT_DEFINITION, PARAMETER_DEF)
+      ).spaces(1)
+      .afterInside(TYPE_NAME, TokenSet.create(VARIABLE_DECLARATION, PARAMETER_LIST, INDEXED_PARAMETER_LIST)).spaces(1)
+      .beforeInside(IDENTIFIER, TokenSet.create(VARIABLE_DECLARATION, PARAMETER_LIST, INDEXED_PARAMETER_LIST)).spaces(1)
+      .after(COMMA).spaces(1)
+      .beforeInside(BLOCK, STATEMENT).spaces(1)
+      .beforeInside(UNCHECKED_BLOCK, STATEMENT).spaces(1)
+      .beforeInside(LBRACE, CONTRACT_DEFINITION).spaces(1)
+      // else on the same line as }
+      .betweenInside(STATEMENT, ELSE, IF_STATEMENT).spaces(1)
+      .between(STATEMENT, COMMENT).spacing(0, Int.MAX_VALUE, 0, true, 1)
+      .after(STATEMENT).lineBreakInCode()
+      .between(LBRACE, RBRACE).none()
+      .afterInside(EXPRESSION, MEMBER_ACCESS_EXPRESSION).none()
+      .beforeInside(IDENTIFIER, MEMBER_ACCESS_EXPRESSION).none()
+      .between(IMPORT_DIRECTIVE, IMPORT_DIRECTIVE).blankLines(0)
+      // 0 lines between event definitions
+      .between(EVENT_DEFINITION, EVENT_DEFINITION).blankLines(0)
+      // 0 lines between error definitions
+      .between(ERROR_DEFINITION, ERROR_DEFINITION).blankLines(0)
+      // 1 line between pragma and import/contract/struct definition
+      .between(PRAGMA_DIRECTIVE, TokenSet.create(IMPORT_DIRECTIVE, CONTRACT_DEFINITION, STRUCT_DEFINITION))
+      .blankLines(1)
+      // 1 line between pragma/import and contract/struct definition
+      .between(
+        TokenSet.create(PRAGMA_DIRECTIVE, IMPORT_DIRECTIVE),
+        topLevelDeclarations
+      ).blankLines(1)
+      // 1 line between contracts/structs
+      .between(
+        topLevelDeclarations,
+        topLevelDeclarations
+      ).blankLines(1)
+      // allow for 0 lines between state variable declarations
+      .between(STATE_VARIABLE_DECLARATION, STATE_VARIABLE_DECLARATION).blankLines(0)
+      // allow for 0 lines between state constant variable declarations
+      .between(CONSTANT_VARIABLE_DECLARATION, CONSTANT_VARIABLE_DECLARATION).blankLines(0)
+      .between(
+        TokenSet.create(
+          FUNCTION_DEFINITION,
+          EVENT_DEFINITION,
+          ERROR_DEFINITION,
+          STRUCT_DEFINITION,
+          STATE_VARIABLE_DECLARATION
+        ),
+        TokenSet.create(
+          FUNCTION_DEFINITION,
+          EVENT_DEFINITION,
+          ERROR_DEFINITION,
+          STRUCT_DEFINITION,
+          STATE_VARIABLE_DECLARATION
+        )
+      ).blankLines(1)
   }
 }

--- a/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
@@ -41,6 +41,7 @@ class SolidityFormattingTest : SolLightPlatformCodeInsightFixtureTestCase() {
   fun testStatementLineBreakAtEnd() = this.doTest()
   fun testBlankLinesBetweenContracts() = this.doTest()
   fun testBlankLinesBetweenContractParts() = this.doTest()
+  fun testBlankLinesBetweenContractAndStruct() = this.doTest()
   fun testSpaceAfterReturns() = this.doTest()
   fun testMultisigWallet() = this.doTest()
   fun testInlineArray() = this.doTest()

--- a/src/test/resources/fixtures/formatter/blankLinesBetweenContractAndStruct-after.sol
+++ b/src/test/resources/fixtures/formatter/blankLinesBetweenContractAndStruct-after.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.0;
+
+library L1 {
+    string c;
+}
+
+contract A1 {}
+
+struct S2 {
+    string c;
+}
+
+enum E1 {
+}
+
+error E1(uint transient);

--- a/src/test/resources/fixtures/formatter/blankLinesBetweenContractAndStruct.sol
+++ b/src/test/resources/fixtures/formatter/blankLinesBetweenContractAndStruct.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.8.0;
+library L1 {
+    string c;
+}
+contract A1 {}
+struct S2 {
+    string c;
+}
+enum E1 {
+}
+error E1(uint transient);

--- a/src/test/resources/fixtures/formatter/enum-after.sol
+++ b/src/test/resources/fixtures/formatter/enum-after.sol
@@ -4,10 +4,13 @@ contract A {
         // hello 2
         A1
     }
+
     enum B {B1, B2}
+
     enum C {
         C1, C2, C3
     }
+
     enum D {
         D1,
         D2,


### PR DESCRIPTION
This PR fixes the top level indentation. Currently, the formatting is the following:

<img width="402" height="353" alt="Screenshot 2025-08-16 at 6 27 41 pm" src="https://github.com/user-attachments/assets/25bbe65b-fc51-4626-ae20-0c2ef9882639" />
