### PR TITLE
formatting: indent the inheritance list correctly

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/formatting/SolFormattingBlock.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/SolFormattingBlock.kt
@@ -77,6 +77,9 @@ open class SolFormattingBlock(
 
       type == CONTRACT_DEFINITION && childType.isContractPart() -> Indent.getNormalIndent()
 
+      // inheritance specifiers
+      type == CONTRACT_DEFINITION && childType == INHERITANCE_SPECIFIER -> Indent.getNormalIndent()
+
       // fields inside structs
       type == STRUCT_DEFINITION && childType == VARIABLE_DECLARATION -> Indent.getNormalIndent()
 

--- a/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
@@ -45,6 +45,7 @@ class SolidityFormattingTest : SolLightPlatformCodeInsightFixtureTestCase() {
   fun testSpaceAfterReturns() = this.doTest()
   fun testMultisigWallet() = this.doTest()
   fun testInlineArray() = this.doTest()
+  fun testInheritanceList() = this.doTest()
 
   override fun getTestDataPath() = "src/test/resources/fixtures/formatter/"
 }

--- a/src/test/resources/fixtures/formatter/inheritanceList-after.sol
+++ b/src/test/resources/fixtures/formatter/inheritanceList-after.sol
@@ -1,0 +1,9 @@
+abstract contract C is
+    S1,
+    S2,
+    S3,
+    S4,
+    S5,
+    S6
+{
+}

--- a/src/test/resources/fixtures/formatter/inheritanceList.sol
+++ b/src/test/resources/fixtures/formatter/inheritanceList.sol
@@ -1,0 +1,9 @@
+abstract contract C is
+S1,
+S2,
+S3,
+S4,
+S5,
+S6
+{
+}


### PR DESCRIPTION
Previously, `S1`, `S2`, etc. weren't indented. 