### PR TITLE
fix #196: format continuation indent for chained calls

### DIFF
--- a/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
+++ b/src/test/kotlin/me/serce/solidity/ide/formatting/format.kt
@@ -46,6 +46,7 @@ class SolidityFormattingTest : SolLightPlatformCodeInsightFixtureTestCase() {
   fun testMultisigWallet() = this.doTest()
   fun testInlineArray() = this.doTest()
   fun testInheritanceList() = this.doTest()
+  fun testChainedMethodCall() = this.doTest()
 
   override fun getTestDataPath() = "src/test/resources/fixtures/formatter/"
 }

--- a/src/test/resources/fixtures/formatter/chainedMethodCall-after.sol
+++ b/src/test/resources/fixtures/formatter/chainedMethodCall-after.sol
@@ -1,0 +1,12 @@
+contract C {
+    function sum1(uint a, uint b, uint c) returns (uint s) {
+        s = a.add(b)
+            .add(c);
+        return s;
+    }
+
+    function sum2(uint a, uint b, uint c) returns (uint s) {
+        return a.add(b)
+            .add(c);
+    }
+}

--- a/src/test/resources/fixtures/formatter/chainedMethodCall.sol
+++ b/src/test/resources/fixtures/formatter/chainedMethodCall.sol
@@ -1,0 +1,12 @@
+contract C {
+    function sum1(uint a, uint b, uint c) returns (uint s) {
+        s = a.add(b)
+        .add(c);
+        return s;
+    }
+
+    function sum2(uint a, uint b, uint c) returns (uint s) {
+        return a.add(b)
+        .add(c);
+    }
+}


### PR DESCRIPTION
This change fixes https://github.com/intellij-solidity/intellij-solidity/issues/196. Additional work might be needed to support typing of the incomplete expressions. 