### PR TITLE
inference: fix inference exception

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/types/types.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/types/types.kt
@@ -136,12 +136,23 @@ data class SolInteger(val unsigned: Boolean, val size: Int, val digitCount: Int?
       return inferIntegerType(numberLiteral.parseLiteral())
     }
 
-    fun inferType(numberLiteral: SolHexLiteral): SolInteger {
+    fun inferType(numberLiteral: SolHexLiteral): SolInteger? {
       val withoutPrefix = numberLiteral.text.substring(3) //
         .removeSurrounding("\"") //
         .removeSurrounding("'") //
         .replace("_", "") // underscore is an allowed separator in hex literals
-      val parse = LiteralParseResult(withoutPrefix.toBigInteger(16), NumericLiteralType.HEX, withoutPrefix.length)
+      val value = when {
+          withoutPrefix.isEmpty() -> BigInteger.ZERO
+          else -> try {
+            withoutPrefix.toBigInteger(16)
+          } catch (_: NumberFormatException) {
+            null
+          }
+      }
+      if (value == null) {
+        return null
+      }
+      val parse = LiteralParseResult(value, NumericLiteralType.HEX, withoutPrefix.length)
       return inferIntegerType(parse)
     }
 

--- a/src/test/kotlin/me/serce/solidity/lang/types/SolExpressionTypeProviderTest.kt
+++ b/src/test/kotlin/me/serce/solidity/lang/types/SolExpressionTypeProviderTest.kt
@@ -386,6 +386,10 @@ class SolExpressionTypeProviderTest : SolTestBase() {
     Assert.assertFalse(bytes2.isAssignableFrom("hex\"12\"".inferType()))
     // bytes2 d = hex"123"; // not allowed
     Assert.assertFalse(bytes2.isAssignableFrom("hex\"123\"".inferType()))
+    // bytes2 g = hex""; // fine
+    Assert.assertTrue(bytes2.isAssignableFrom("hex\"\"".inferType()))
+    // bytes2 c = hex"zzz"; // not allowed
+    Assert.assertFalse(bytes2.isAssignableFrom("hex\"zzz\"".inferType()))
     // bytes2 e = "x"; // not allowed
     Assert.assertFalse(bytes2.isAssignableFrom("\"x\"".inferType()))
     // bytes2 f = "xyz"; // not allowed


### PR DESCRIPTION
This PR fixes a `NumberFormatException` spotted during testing

```
java.lang.NumberFormatException: Zero length BigInteger
	at java.base/java.math.BigInteger.<init>(BigInteger.java:491)
	at me.serce.solidity.lang.types.SolInteger$Companion.inferType(types.kt:144)
	at me.serce.solidity.lang.types.InferenceKt.inferExprType(inference.kt:170)
	at me.serce.solidity.lang.types.InferenceKt._get_type_$lambda$20$lambda$19(inference.kt:259)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:173)
	at com.intellij.psi.impl.PsiCachedValueImpl$Direct.doCompute(PsiCachedValueImpl.kt:77)
```