### PR TITLE
fix: error on empty first() call

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/resolve/engine.kt
@@ -307,11 +307,10 @@ object SolResolver {
       }
       when {
         names.size > 2 -> {
-          val indexNameWithoutAliases = names.indexOf(names.find { name ->
-            //TODO check if non empty to be able to call first
-            val resolved = resolveTypeNameUsingImports(name).first()
-            resolved !is SolImportAlias || !isAliasOfFile(resolved)
-          })
+            val indexNameWithoutAliases = names.indexOf(names.find { name ->
+                val resolved = resolveTypeNameUsingImports(name).firstOrNull()
+                resolved != null && (resolved !is SolImportAlias || !isAliasOfFile(resolved))
+            })
           if (names.size - indexNameWithoutAliases == 2) {
             resolveTypeNameUsingImports(names[indexNameWithoutAliases])
               .filterIsInstance<SolContractDefinition>()


### PR DESCRIPTION
Fix a first() call to an empty set generating an unhandled error