### PR TITLE
feat: add clz evm opcode

### DIFF
--- a/src/main/grammars/solidity.bnf
+++ b/src/main/grammars/solidity.bnf
@@ -593,7 +593,7 @@ private YulIdentifier ::= Identifier
 private YulEVMBuiltin ::=
         	'stop' | 'add' | 'sub' | 'mul' | 'div' | 'sdiv' | 'mod' | 'smod' | 'exp' | 'not'
         	| 'lt' | 'gt' | 'slt' | 'sgt' | 'eq' | 'iszero' | 'and' | 'or' | 'xor' | 'byte'
-        	| 'shl' | 'shr' | 'sar' | 'addmod' | 'mulmod' | 'signextend' | 'keccak256'
+        	| 'shl' | 'shr' | 'sar' | 'clz' | 'addmod' | 'mulmod' | 'signextend' | 'keccak256'
         	| 'pop' | 'mload' | 'mstore' | 'mstore8' | 'sload' | 'sstore' | 'tload' | 'tstore' | 'msize' | 'gas'
         	| 'address' | 'balance' | 'selfbalance' | 'caller' | 'callvalue' | 'calldataload'
         	| 'calldatasize' | 'calldatacopy' | 'extcodesize' | 'extcodecopy' | 'returndatasize'


### PR DESCRIPTION
Solidity 0.8.31 introduce a new EVM opcode : clz 
https://www.soliditylang.org/blog/2025/12/03/solidity-0.8.31-release-announcement/
https://docs.soliditylang.org/en/v0.8.31/grammar.html#syntax-rule-SolidityLexer.YulEVMBuiltin