### PR TITLE
specifies the language for code style settings

### DIFF
--- a/src/main/kotlin/me/serce/solidity/ide/formatting/settings.kt
+++ b/src/main/kotlin/me/serce/solidity/ide/formatting/settings.kt
@@ -14,6 +14,8 @@ import org.jdom.Element
 import javax.swing.JCheckBox
 
 class SolCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
+  override fun getLanguage(): Language = SolidityLanguage
+
   override fun createCustomSettings(settings: CodeStyleSettings) = SolCodeStyleSettings(true, settings)
 
   override fun getConfigurableDisplayName() = SolidityLanguage.displayName


### PR DESCRIPTION
This PR fixes: 
```
om.intellij.diagnostic.PluginException: Legacy configurable id calculation mode from localizable name will be used for configurable class me.serce.solidity.ide.formatting.SolCodeStyleSettingsProvider. Please override getConfigurableId or getLanguage. [Plugin: me.serce.solidity]
    at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
    at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
    at com.intellij.diagnostic.PluginException.logPluginError(PluginException.java:112)
    at com.intellij.psi.codeStyle.CodeStyleSettingsProvider.getConfigurableId(CodeStyleSettingsProvider.java:71)
    at com.intellij.application.options.CodeStyleConfigurableWrapper.getId(CodeStyleConfigurableWrapper.java:112)
    at com.intellij.ide.ui.search.SearchableOptionsRegistrarImplKt.filterById(SearchableOptionsRegistrarImpl.kt:444)
    at com.intellij.ide.ui.search.SearchableOptionsRegistrarImplKt.access$filterById(SearchableOptionsRegistrarImpl.kt:1)
    at com.intellij.ide.ui.search.SearchableOptionsRegistrarImpl.getConfigurables(SearchableOptionsRegistrarImpl.kt:262)
    at com.intellij.openapi.options.newEditor.SettingsFilter.update(SettingsFilter.kt:192)
    at com.intellij.openapi.options.newEditor.SettingsFilter.access$update(SettingsFilter.kt:43)

```