### PR TITLE
add minimal support for writing jmh benchmarks

### DIFF
--- a/src/jmh/README.md
+++ b/src/jmh/README.md
@@ -1,0 +1,23 @@
+# JMH Benchmarks for IntelliJ Solidity
+
+This directory contains benchmarks for the IntelliJ Solidity plugin using [JMH](https://openjdk.org/projects/code-tools/jmh/).
+
+The benchmarks exist here not to get absolute numbers, but rather to provide a way to measure any performance impact of the changes made to the plugin.
+
+## Running a benchmark
+
+To run all benchmarks, use the following Gradle command from the project root:
+
+```bash
+./gradlew jmh
+```
+
+To run a specific benchmark:
+
+```bash
+./gradlew jmh -Pjmh.includes='SolidityParserBenchmark'
+```
+
+## Project fixtures
+
+As it's often hard to get realistic input data for benchmarks, `ProjectFixtureSupport` provides a set of fixtures that are derived from real-world Solidity projects.

--- a/src/jmh/kotlin/me/serce/solidity/lang/benchmark/ProjectFixtureSupport.kt
+++ b/src/jmh/kotlin/me/serce/solidity/lang/benchmark/ProjectFixtureSupport.kt
@@ -1,0 +1,104 @@
+package me.serce.solidity.lang.benchmark
+
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.Comparator
+
+/**
+ * Support for preparing realistic solidity projects for benchmarks.
+ */
+object ProjectFixtureSupport {
+  data class ExternalRepo(
+    val name: String,
+    val url: String,
+    val ref: String,
+  )
+
+  private val registeredRepos: MutableMap<String, ExternalRepo> = linkedMapOf(
+    "openzeppelin" to ExternalRepo(
+      name = "openzeppelin-contracts",
+      url = "https://github.com/OpenZeppelin/openzeppelin-contracts.git",
+      ref = "v5.5.0",
+    ),
+  )
+
+  fun prepareExternalRepo(key: String): Path {
+    val repo = registeredRepos[key]
+      ?: throw IllegalArgumentException("Unknown external repo key: $key")
+    val checkoutName = "${repo.name}-${repo.ref}"
+    return prepareGitFixture(checkoutName, repo.url, repo.ref)
+  }
+
+  fun prepareOpenZeppelinFixture(): Path = prepareExternalRepo("openzeppelin")
+
+  fun loadSoliditySources(contractsRoot: Path): List<SolSourceFile> {
+    if (!Files.isDirectory(contractsRoot)) {
+      throw IOException("Contracts directory does not exist: $contractsRoot")
+    }
+    val sources = Files.walk(contractsRoot).use { paths ->
+      paths
+        .filter { Files.isRegularFile(it) && it.toString().endsWith(".sol") }
+        .map { path ->
+          val content = Files.readString(path)
+          val relativePath = contractsRoot.relativize(path).toString()
+          SolSourceFile(relativePath, content)
+        }
+        .toList()
+    }
+    if (sources.isEmpty()) {
+      throw IOException("No Solidity sources found under: $contractsRoot")
+    }
+    return sources
+  }
+
+  private fun prepareGitFixture(name: String, url: String, ref: String): Path {
+    val baseDir = Paths.get(System.getProperty("java.io.tmpdir"), "intellij-solidity-fixtures")
+    Files.createDirectories(baseDir)
+    val checkoutDir = baseDir.resolve(name)
+    if (Files.isDirectory(checkoutDir.resolve(".git"))) {
+      return checkoutDir
+    }
+    if (Files.exists(checkoutDir)) {
+      deleteDir(checkoutDir)
+    }
+    runCommand(baseDir, "git", "clone", "--depth", "1", "--branch", ref, url, checkoutDir.toString())
+    return checkoutDir
+  }
+
+  private fun runCommand(workDir: Path, vararg command: String) {
+    val builder = ProcessBuilder(*command)
+    builder.directory(workDir.toFile())
+    builder.redirectErrorStream(true)
+    val process = builder.start()
+    val output = StringBuilder()
+    BufferedReader(InputStreamReader(process.inputStream, StandardCharsets.UTF_8)).use { reader ->
+      reader.forEachLine { line ->
+        output.append(line).append(System.lineSeparator())
+      }
+    }
+    val exitCode = process.waitFor()
+    if (exitCode != 0) {
+      throw IOException(
+        "Command failed ($exitCode): ${command.joinToString(" ")}\n$output"
+      )
+    }
+  }
+
+  private fun deleteDir(path: Path) {
+    Files.walk(path)
+      .sorted(Comparator.reverseOrder())
+      .forEach { entry ->
+        Files.delete(entry)
+      }
+  }
+}
+
+data class SolSourceFile(
+  val relativePath: String,
+  val contents: String,
+)

--- a/src/jmh/kotlin/me/serce/solidity/lang/benchmark/SolidityParserBenchmark.kt
+++ b/src/jmh/kotlin/me/serce/solidity/lang/benchmark/SolidityParserBenchmark.kt
@@ -1,0 +1,84 @@
+package me.serce.solidity.lang.benchmark
+
+import com.intellij.core.CoreApplicationEnvironment
+import com.intellij.core.CoreProjectEnvironment
+import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiFileFactory
+import me.serce.solidity.lang.SolidityFileType
+import me.serce.solidity.lang.SolidityLanguage
+import me.serce.solidity.lang.core.SolidityParserDefinition
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+open class SolidityParserBenchmark {
+  private lateinit var ijEnv: IjBenchEnvironment
+  private lateinit var psiFileFactory: PsiFileFactory
+  private lateinit var sources: List<SolSourceFile>
+
+  @Param("openzeppelin")
+  var source: String = "openzeppelin"
+
+  @Setup(Level.Trial)
+  fun setUp() {
+    ijEnv = IjBenchEnvironment()
+    psiFileFactory = PsiFileFactory.getInstance(ijEnv.project)
+    sources = loadSources(source)
+  }
+
+  @TearDown(Level.Trial)
+  fun tearDown() {
+    ijEnv.close()
+  }
+
+  @Benchmark
+  fun parseAllContractsInTheProject(): Int {
+    var parsedFiles = 0
+    for (sourceFile in sources) {
+      val file = psiFileFactory.createFileFromText(
+        sourceFile.relativePath,
+        SolidityFileType,
+        sourceFile.contents,
+      )
+      if (file.node != null) {
+        parsedFiles++
+      }
+    }
+    return parsedFiles
+  }
+
+  private fun loadSources(source: String): List<SolSourceFile> {
+    if (source == "openzeppelin") {
+      val root = ProjectFixtureSupport.prepareOpenZeppelinFixture()
+      return ProjectFixtureSupport.loadSoliditySources(root.resolve("contracts"))
+    }
+    throw IllegalArgumentException("Unsupported benchmark source: $source")
+  }
+
+  private class IjBenchEnvironment : AutoCloseable {
+    private val disposable: Disposable = Disposer.newDisposable("solidity-benchmark")
+    private val applicationEnvironment = CoreApplicationEnvironment(disposable)
+    private val projectEnvironment = CoreProjectEnvironment(disposable, applicationEnvironment)
+
+    val project: Project = projectEnvironment.project
+
+    init {
+      LanguageParserDefinitions.INSTANCE.addExplicitExtension(
+        SolidityLanguage,
+        SolidityParserDefinition(),
+      )
+    }
+
+    override fun close() {
+      Disposer.dispose(disposable)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a minimal setup for writing JMH benchmarks that can help to evaluate the performance impact of the changes. The initial PR focuses on the parser. 