### PR TITLE
feat: reduce keyword completion priority

### DIFF
--- a/src/main/kotlin/me/serce/solidity/lang/completion/keywords.kt
+++ b/src/main/kotlin/me/serce/solidity/lang/completion/keywords.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.editor.EditorModificationUtil
 import com.intellij.openapi.project.DumbAware
 import com.intellij.util.ProcessingContext
 
-const val KEYWORD_PRIORITY = 10.0
+const val KEYWORD_PRIORITY = -1.0
 
 val KEYWORD_TYPE = arrayOf(
   "address ",


### PR DESCRIPTION
I reduced the keyword completion priority to avoid them being suggested first. 
It’s annoying to see them in member access completion.